### PR TITLE
fix(build): force pure-Go DNS resolver in static Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,16 +370,55 @@ jobs:
           echo "commit=$COMMIT" >> $GITHUB_OUTPUT
           echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
 
-      # Build Linux web interface for multiple architectures
+      # Build Linux web interface for multiple architectures.
+      #
+      # netgo/osusergo are REQUIRED here, not optional. This binary is fully
+      # statically linked (-extldflags "-static") but still needs cgo for
+      # mattn/go-sqlite3 and par2go. Without netgo, net/cgo_unix.go is compiled
+      # in and DNS goes through glibc getaddrinfo -> NSS, which dlopen()s
+      # libnss_*.so from the *host* at runtime. Loading the host's glibc
+      # modules into a process with a different statically-linked glibc leaves
+      # the loader globals uninitialised, and the NSS code divides by a zero
+      # page size -> SIGFPE. Users hit this the moment they pressed "Test
+      # Connection" (issue #243); GODEBUG=netdns=go was the manual workaround.
+      # netgo compiles the cgo resolver out entirely, so there is nothing left
+      # to dlopen. osusergo does the same for os/user's getpwuid NSS path.
       - name: Build Linux Web Interface (amd64)
         run: |
           mkdir -p build
           CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
             -trimpath \
             -a \
+            -tags netgo,osusergo \
             -ldflags '-linkmode external -extldflags "-static" -s -w -X "main.Version=${{ steps.version.outputs.version }}" -X "main.GitCommit=${{ steps.version.outputs.commit }}" -X "main.Timestamp=${{ steps.version.outputs.timestamp }}"' \
             -o build/postie-web-linux-amd64 \
             ./cmd/web
+        env:
+          CC: gcc
+
+      # Catch a netgo regression in CI instead of at user launch time (#243).
+      # The shipped binary is stripped (-s -w) and has no usable symbol table,
+      # so rebuild the same package with the same tags unstripped and inspect
+      # that instead. Build tags are what decide which net/*.go files compile,
+      # so the symbols are identical either way.
+      - name: Verify pure-Go DNS resolver is linked
+        run: |
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+            -tags netgo,osusergo \
+            -o /tmp/postie-web-symcheck \
+            ./cmd/web
+          syms=$(go tool nm /tmp/postie-web-symcheck)
+          # Positive control: proves the symbol table is readable, so the
+          # negative assertion below cannot pass vacuously.
+          if ! grep -q 'net\.goLookupIPFiles' <<<"$syms"; then
+            echo "::error::symbol table unreadable - the resolver check would pass vacuously"
+            exit 1
+          fi
+          if grep -q 'net\.cgoLookupHostIP' <<<"$syms"; then
+            echo "::error::cgo DNS resolver linked into the static binary - SIGFPE regression (#243)"
+            exit 1
+          fi
+          echo "OK: pure-Go DNS resolver, no cgo getaddrinfo path"
         env:
           CC: gcc
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,10 +51,14 @@ COPY ./frontend/embed.go ./frontend/embed.go
 COPY --from=frontend-builder /app/frontend/build ./frontend/build
 
 # Build web binary with enhanced cache mount for native architecture
+# netgo/osusergo are required: this is a fully static cgo binary, and without
+# them DNS goes through glibc getaddrinfo -> NSS, which dlopen()s the host's
+# libnss_*.so into a process with a different statically-linked glibc and
+# crashes with SIGFPE (issue #243). netgo compiles that path out entirely.
 RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     --mount=type=cache,target=/tmp/go-build-cache,sharing=locked \
     CGO_ENABLED=1 GOOS=linux \
-    go build -a -ldflags '-linkmode external -extldflags "-static"' -o postie-web cmd/web/main.go
+    go build -a -tags netgo,osusergo -ldflags '-linkmode external -extldflags "-static"' -o postie-web cmd/web/main.go
 
 # Final stage - use LinuxServer.io base image (has s6-overlay + PUID/PGID support)
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -31,10 +31,14 @@ COPY ./frontend/embed.go ./frontend/embed.go
 COPY ./frontend/build ./frontend/build
 
 # Build web binary with enhanced cache mount for native architecture
+# netgo/osusergo are required: this is a fully static cgo binary, and without
+# them DNS goes through glibc getaddrinfo -> NSS, which dlopen()s the host's
+# libnss_*.so into a process with a different statically-linked glibc and
+# crashes with SIGFPE (issue #243). netgo compiles that path out entirely.
 RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     --mount=type=cache,target=/tmp/go-build-cache,sharing=locked \
     CGO_ENABLED=1 GOOS=linux \
-    go build -a -ldflags '-linkmode external -extldflags "-static"' -o postie-web ./cmd/web
+    go build -a -tags netgo,osusergo -ldflags '-linkmode external -extldflags "-static"' -o postie-web ./cmd/web
 
 # Final stage - use LinuxServer.io base image (has s6-overlay + PUID/PGID support)
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy


### PR DESCRIPTION
Fixes #243

## Problem

Pressing **Test Connection** during web-UI setup killed the `postie-web` process with `SIGFPE: floating-point exception`. Despite how it presents, this is not a frontend bug — the Go server dies and takes the UI down with it.

`postie-web-linux-amd64` is built with `CGO_ENABLED=1` (genuinely needed for `mattn/go-sqlite3` and `par2go`) **and** `-extldflags "-static"`. With cgo enabled, Go compiles in `net/cgo_unix.go` and routes DNS through glibc `getaddrinfo` → NSS. NSS `dlopen`s `libnss_*.so` from the **host** at runtime, so a binary carrying Ubuntu's statically-linked glibc pulls in the user's glibc (2.44 on Arch, in the report). The loader globals were never initialized for that path, and the NSS code divides by a zero page size.

The crash dump in the issue confirms every step:

- `instruction bytes: 0x49 0xf7 0xf0` decodes to `div %r8`, and the register dump shows `r8 0x0` → divide-by-zero → `SIGFPE`.
- `PC=0x7f34cd5729d5` is a shared-library address *inside an otherwise fully static binary* — i.e. a `dlopen`ed NSS module.
- The failing frame is `net.cgoLookupHostIP` at `net/cgo_unix.go:174`.
- `GODEBUG=netdns=go` working around it is the confirming signal: it bypasses `getaddrinfo` entirely.

## Fix

Add `-tags netgo,osusergo` to every statically-linked Linux build. `netgo` swaps `cgo_unix.go` for `cgo_stub.go` at compile time:

```go
// cgo_unix.go
//go:build !netgo && ((cgo && unix) || darwin)
```

So the `getaddrinfo` path is absent from the binary and there is nothing left to `dlopen`. `osusergo` closes the same hole for `os/user`'s `getpwuid` NSS path. This preserves static linking and its portability, unlike the alternative of dropping `-static`.

Three affected sites, all fixed:

| File | Build |
|---|---|
| `.github/workflows/release.yml` | `postie-web-linux-amd64` (the reported binary) |
| `docker/Dockerfile` | local/dev image |
| `docker/Dockerfile.ci` | released images |

The Linux CLI build is dynamically linked, so it was never affected. Windows static builds don't use glibc NSS.

## Regression guard

Added a CI step that fails the release if the cgo resolver ever comes back.

One trap worth calling out: the obvious version of this check — `go tool nm` on the shipped binary — **passes unconditionally**, because `-s -w` strips the symbol table down to ~70 symbols and the grep finds nothing either way. The step therefore rebuilds the same package with the same tags unstripped, and pairs the negative assertion with a positive control (`net.goLookupIPFiles` must be present) so an unreadable symbol table fails loudly instead of passing vacuously.

## Verification

- Builds clean with the new tags; `go vet` clean.
- Full suite: **17 packages, 0 failures**.
- Guard exercised all three ways against the real `cmd/web` binary: buggy config → correctly fails; fixed config → passes; stripped binary → correctly rejected as vacuous.
- `release.yml` validated as YAML; the verify step is ordered after the frontend-artifact download, so `./cmd/web` compiles.
- The `-lc++` linker warnings seen locally are pre-existing macOS noise from par2go — present with and without this change.

## Behavioral trade-off

The pure-Go resolver reads `/etc/resolv.conf` and `/etc/hosts` but does **not** honor NSS plugins (mDNS/`.local`, sssd, LDAP). For resolving public NNTP provider hostnames this is fine, and it is exactly what the reporter is already running successfully via `GODEBUG=netdns=go`.

## Test plan

- [x] Release workflow's new `Verify pure-Go DNS resolver is linked` step passes.
- [x] Docker images build.
- [x] On a glibc-2.44 host (e.g. Arch), the new `postie-web-linux-amd64` completes **Test Connection** without `GODEBUG=netdns=go`.
