### PR TITLE
docs: update GitHub org scope from javi11 to kipsilabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Postie
 
-[![Build](https://github.com/javi11/postie/actions/workflows/pull-request.yml/badge.svg)](https://github.com/javi11/postie/actions/workflows/pull-request.yml)
-[![Coverage](https://github.com/javi11/postie/actions/workflows/coverage.yml/badge.svg)](https://github.com/javi11/postie/actions/workflows/coverage.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/javi11/postie)](https://goreportcard.com/report/github.com/javi11/postie)
+[![Build](https://github.com/kipsilabs/postie/actions/workflows/pull-request.yml/badge.svg)](https://github.com/kipsilabs/postie/actions/workflows/pull-request.yml)
+[![Coverage](https://github.com/kipsilabs/postie/actions/workflows/coverage.yml/badge.svg)](https://github.com/kipsilabs/postie/actions/workflows/coverage.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kipsilabs/postie)](https://goreportcard.com/report/github.com/kipsilabs/postie)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/qbt52hh7sjd)
@@ -32,7 +32,7 @@ A high-performance Usenet binary poster written in Go, inspired by Nyuu-Obfuscat
 
 ```bash
 # Create docker-compose.yml
-curl -o docker-compose.yml https://raw.githubusercontent.com/javi11/postie/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/kipsilabs/postie/main/docker-compose.yml
 
 # Start Postie
 docker-compose up -d
@@ -42,9 +42,9 @@ docker-compose up -d
 
 ### Binary Download
 
-[![Download for Windows](https://img.shields.io/badge/Windows-Download-0078d4?style=for-the-badge&logo=windows)](https://github.com/javi11/postie/releases/latest/download/postie_windows_amd64.zip)
-[![Download for macOS](https://img.shields.io/badge/macOS-Download-0078d4?style=for-the-badge&logo=apple)](https://github.com/javi11/postie/releases/latest/download/postie_darwin_amd64.zip)
-[![Download for Linux](https://img.shields.io/badge/Linux-Download-0078d4?style=for-the-badge&logo=linux)](https://github.com/javi11/postie/releases/latest/download/postie_linux_amd64.zip)
+[![Download for Windows](https://img.shields.io/badge/Windows-Download-0078d4?style=for-the-badge&logo=windows)](https://github.com/kipsilabs/postie/releases/latest/download/postie_windows_amd64.zip)
+[![Download for macOS](https://img.shields.io/badge/macOS-Download-0078d4?style=for-the-badge&logo=apple)](https://github.com/kipsilabs/postie/releases/latest/download/postie_darwin_amd64.zip)
+[![Download for Linux](https://img.shields.io/badge/Linux-Download-0078d4?style=for-the-badge&logo=linux)](https://github.com/kipsilabs/postie/releases/latest/download/postie_linux_amd64.zip)
 
 ## Documentation
 
@@ -63,7 +63,7 @@ For detailed documentation, installation instructions, configuration options, an
 ### Building from Source
 
 ```bash
-git clone https://github.com/javi11/postie.git
+git clone https://github.com/kipsilabs/postie.git
 cd postie
 go build
 ```
@@ -71,7 +71,7 @@ go build
 ### Installing with Go
 
 ```bash
-go install github.com/javi11/postie@latest
+go install github.com/kipsilabs/postie@latest
 ```
 
 ## License

--- a/docs/docs/first-setup.md
+++ b/docs/docs/first-setup.md
@@ -12,8 +12,8 @@ Before starting, install Postie using one of the available methods — see the [
 
 | Method | How to run |
 |--------|-----------|
-| **Desktop App** (Windows / macOS) | Download from [GitHub Releases](https://github.com/javi11/postie/releases/latest) and launch the app |
-| **Docker** | `docker run -p 8080:8080 -v $(pwd)/config:/config javi11/postie` |
+| **Desktop App** (Windows / macOS) | Download from [GitHub Releases](https://github.com/kipsilabs/postie/releases/latest) and launch the app |
+| **Docker** | `docker run -p 8080:8080 -v $(pwd)/config:/config kipsilabs/postie` |
 | **Binary** | Download from Releases, then run `./postie` |
 
 > 💡 The setup wizard launches automatically the first time you open Postie.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -12,20 +12,20 @@ There are several ways to install and run Postie. Choose the method that best su
 
 Download the latest release for your platform:
 
-<a href="https://github.com/javi11/postie/releases/latest/download/postie-gui-windows-amd64.zip">
+<a href="https://github.com/kipsilabs/postie/releases/latest/download/postie-gui-windows-amd64.zip">
   <img src="/img/download-for-windows.webp" alt="Download for Windows" width="200" height="60" />
 </a>
-<a href="https://github.com/javi11/postie/releases/latest/download/postie-gui-macos-universal.zip">
+<a href="https://github.com/kipsilabs/postie/releases/latest/download/postie-gui-macos-universal.zip">
   <img src="/img/download-for-mac.png" alt="Download for macOS" width="200" height="60" />
 </a>
 
-[![View All Releases](https://img.shields.io/badge/All%20Releases-View-6c757d?style=for-the-badge&logo=github)](https://github.com/javi11/postie/releases/latest)
+[![View All Releases](https://img.shields.io/badge/All%20Releases-View-6c757d?style=for-the-badge&logo=github)](https://github.com/kipsilabs/postie/releases/latest)
 
 ## Binary Installation
 
 The easiest way to get started is by downloading a pre-built binary:
 
-1. Go to the [releases page](https://github.com/javi11/postie/releases) or use the download buttons above
+1. Go to the [releases page](https://github.com/kipsilabs/postie/releases) or use the download buttons above
 2. Download the appropriate binary for your platform
 3. Extract the archive
 4. Run Postie to start the web interface:
@@ -67,7 +67,7 @@ Postie provides a complete Docker setup that includes the web interface for easy
 services:
   postie:
     container_name: postie
-    image: ghcr.io/javi11/postie:latest
+    image: ghcr.io/kipsilabs/postie:latest
     ports:
       - "8080:8080"
     volumes:
@@ -90,7 +90,7 @@ For ARM devices like Raspberry Pi, you may want to explicitly specify the platfo
 services:
   postie:
     container_name: postie
-    image: ghcr.io/javi11/postie:latest
+    image: ghcr.io/kipsilabs/postie:latest
     platform: linux/arm64  # Explicitly specify ARM64
     ports:
       - "8080:8080"
@@ -135,7 +135,7 @@ docker run -d \
   -v ./output:/output \
   -e PUID=1000 \
   -e PGID=1000 \
-  ghcr.io/javi11/postie:latest
+  ghcr.io/kipsilabs/postie:latest
 ```
 
 #### ARM Device Configuration
@@ -152,17 +152,17 @@ docker run -d \
   -v ./output:/output \
   -e PUID=1000 \
   -e PGID=1000 \
-  ghcr.io/javi11/postie:latest
+  ghcr.io/kipsilabs/postie:latest
 ```
 
 #### Available Image Tags
 
 You can also use architecture-specific tags if needed:
 
-- `ghcr.io/javi11/postie:latest` - Multi-arch manifest (recommended)
-- `ghcr.io/javi11/postie:v{version}` - Multi-arch manifest for specific version
-- `ghcr.io/javi11/postie:v{version}-amd64` - AMD64 specific
-- `ghcr.io/javi11/postie:v{version}-arm64` - ARM64 specific
+- `ghcr.io/kipsilabs/postie:latest` - Multi-arch manifest (recommended)
+- `ghcr.io/kipsilabs/postie:v{version}` - Multi-arch manifest for specific version
+- `ghcr.io/kipsilabs/postie:v{version}-amd64` - AMD64 specific
+- `ghcr.io/kipsilabs/postie:v{version}-arm64` - ARM64 specific
 
 ### Web Interface Access
 
@@ -283,7 +283,7 @@ chmod +x postie
 
 The project provides native ARM64 binaries for Linux:
 
-1. Download the ARM64 binary from the [releases page](https://github.com/javi11/postie/releases)
+1. Download the ARM64 binary from the [releases page](https://github.com/kipsilabs/postie/releases)
    - Look for files ending in `-linux-arm64.tar.gz`
 2. Follow the same Linux installation steps above
 3. The ARM64 binary provides optimal performance on ARM devices
@@ -295,7 +295,7 @@ The project provides native ARM64 binaries for Linux:
 
 #### Web Interface with Binary
 
-1. Download [postie-web](https://github.com/javi11/postie/releases/latest/download/postie-web-linux-amd64.tar.gz)
+1. Download [postie-web](https://github.com/kipsilabs/postie/releases/latest/download/postie-web-linux-amd64.tar.gz)
 2. Extract the file
 3. Start Postie with the web server enabled `./postie-web --port 80080`
 4. Open your web browser
@@ -307,7 +307,7 @@ The project provides native ARM64 binaries for Linux:
 If you prefer to build from source:
 
 ```bash
-git clone https://github.com/javi11/postie.git
+git clone https://github.com/kipsilabs/postie.git
 cd postie
 go build
 ```
@@ -317,7 +317,7 @@ go build
 If you have Go installed, you can install Postie directly:
 
 ```bash
-go install github.com/javi11/postie@latest
+go install github.com/kipsilabs/postie@latest
 ```
 
 ## System Requirements

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -25,7 +25,7 @@ Start Postie using Docker or the binary:
 **Docker:**
 
 ```bash
-docker run -p 8080:8080 -v $(pwd)/config:/config -v $(pwd)/output:/output javi11/postie
+docker run -p 8080:8080 -v $(pwd)/config:/config -v $(pwd)/output:/output kipsilabs/postie
 ```
 
 **Binary:**

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'javi11', // Usually your GitHub org/user name.
+  organizationName: 'kipsilabs', // Usually your GitHub org/user name.
   projectName: 'postie', // Usually your repo name.
 
   onBrokenLinks: 'throw',
@@ -39,7 +39,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           editUrl:
-            'https://github.com/javi11/postie/tree/main/docs/',
+            'https://github.com/kipsilabs/postie/tree/main/docs/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -65,7 +65,7 @@ const config: Config = {
           label: 'Documentation',
         },
         {
-          href: 'https://github.com/javi11/postie',
+          href: 'https://github.com/kipsilabs/postie',
           label: 'GitHub',
           position: 'right',
         },
@@ -92,11 +92,11 @@ const config: Config = {
           items: [
             {
               label: 'GitHub Issues',
-              href: 'https://github.com/javi11/postie/issues',
+              href: 'https://github.com/kipsilabs/postie/issues',
             },
             {
               label: 'GitHub Discussions',
-              href: 'https://github.com/javi11/postie/discussions',
+              href: 'https://github.com/kipsilabs/postie/discussions',
             },
           ],
         },
@@ -105,7 +105,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/javi11/postie',
+              href: 'https://github.com/kipsilabs/postie',
             },
           ],
         },

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -25,14 +25,14 @@ function HomepageHeader() {
           </Link>
           <Link
             className="button button--outline button--lg button--secondary"
-            to="https://github.com/javi11/postie"
+            to="https://github.com/kipsilabs/postie"
             style={{ marginLeft: '10px' }}>
             GitHub
           </Link>
         </div>
         <div className={styles.buttons} style={{ marginTop: '20px' }}>
           <Link
-            to="https://github.com/javi11/postie/releases/latest/download/postie-gui-windows-amd64.zip"
+            to="https://github.com/kipsilabs/postie/releases/latest/download/postie-gui-windows-amd64.zip"
             style={{ margin: '5px', display: 'inline-block' }}>
             <img 
               src="/img/download-for-windows.webp" 
@@ -41,7 +41,7 @@ function HomepageHeader() {
             />
           </Link>
           <Link
-            to="https://github.com/javi11/postie/releases/latest/download/postie-gui-macos-universal.zip"
+            to="https://github.com/kipsilabs/postie/releases/latest/download/postie-gui-macos-universal.zip"
             style={{ margin: '5px', display: 'inline-block' }}>
             <img 
               src="/img/download-for-mac.png" 
@@ -52,7 +52,7 @@ function HomepageHeader() {
         </div>
         <div style={{ marginTop: '15px', textAlign: 'center' }}>
           <Link
-            to="https://github.com/javi11/postie/releases/latest"
+            to="https://github.com/kipsilabs/postie/releases/latest"
             style={{ color: 'var(--ifm-hero-text-color)', textDecoration: 'underline' }}>
             View all releases
           </Link>
@@ -126,7 +126,7 @@ export default function Home(): ReactNode {
   -v ./config:/config \\
   -v ./watch:/watch \\
   -v ./output:/output \\
-  ghcr.io/javi11/postie:latest`}</code>
+  ghcr.io/kipsilabs/postie:latest`}</code>
               </pre>
               <div style={{ textAlign: 'center', marginTop: '1rem' }}>
                 <p>Then open <strong>http://localhost:8080</strong> in your browser</p>


### PR DESCRIPTION
## Summary
- Repo now lives at kipsilabs/postie; update README, docs site, and docusaurus config links to match
- Swap `github.com/javi11/postie`, `raw.githubusercontent.com/javi11/postie`, and `ghcr.io/javi11/postie` references to the `kipsilabs` scope
- Leave `javi11/nxg` link in configuration.md untouched (unrelated project, not part of kipsilabs org)

## Test plan
- [ ] Spot-check rendered docs site links resolve correctly
- [ ] Confirm GHCR image publishes under `ghcr.io/kipsilabs/postie` once CI runs on this branch