### PR TITLE
fix(queue): pending-status query used non-existent goqite created_at column

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -946,9 +946,19 @@ func (q *Queue) getMergedItemsByStatus(order string, offset, limit int) ([]Queue
 			break
 		}
 
-		var items []QueueItem
-		var err error
+		// The offset must be consumed against the bucket's total size, not the
+		// page it returns: a bucket smaller than the offset returns nothing,
+		// and reducing by that empty page would skip items at the boundary.
+		count, err := q.countItemsByStatus(status)
+		if err != nil {
+			return nil, err
+		}
+		if currentOffset >= count {
+			currentOffset -= count
+			continue
+		}
 
+		var items []QueueItem
 		switch status {
 		case "running":
 			items, err = q.getInProgressItemsPaginated("started_at DESC", currentOffset, remaining)
@@ -959,24 +969,39 @@ func (q *Queue) getMergedItemsByStatus(order string, offset, limit int) ([]Queue
 		case "error":
 			items, err = q.getErroredItemsPaginated(currentOffset, remaining)
 		}
-
 		if err != nil {
 			return nil, err
 		}
-
-		// Adjust offset for next category
-		if len(items) < currentOffset {
-			currentOffset -= len(items)
-			continue
-		}
 		currentOffset = 0
 
-		// Add items and reduce remaining count
 		allItems = append(allItems, items...)
 		remaining -= len(items)
 	}
 
 	return allItems, nil
+}
+
+// countItemsByStatus returns the number of items in the table backing status.
+func (q *Queue) countItemsByStatus(status string) (int, error) {
+	var query string
+	switch status {
+	case "running":
+		query = "SELECT COUNT(*) FROM in_progress_items"
+	case "pending":
+		query = "SELECT COUNT(*) FROM goqite WHERE queue = 'file_jobs'"
+	case "complete":
+		query = "SELECT COUNT(*) FROM completed_items"
+	case "error":
+		query = "SELECT COUNT(*) FROM errored_items"
+	default:
+		return 0, fmt.Errorf("unknown status %q", status)
+	}
+
+	var count int
+	if err := q.db.QueryRow(query).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count %s items: %w", status, err)
+	}
+	return count, nil
 }
 
 // getInProgressItemsPaginated returns paginated in-progress items
@@ -1200,8 +1225,10 @@ func (q *Queue) getPendingItemsPaginated(orderBy string, offset, limit int) ([]Q
 	// Map column names for goqite table (which uses JSON body)
 	var sortColumn string
 	switch orderBy {
-	case "created_at DESC", "created_at ASC":
-		sortColumn = orderBy
+	case "created_at DESC":
+		sortColumn = "created DESC"
+	case "created_at ASC":
+		sortColumn = "created ASC"
 	case "size DESC":
 		sortColumn = "CAST(json_extract(body, '$.size') AS INTEGER) DESC"
 	case "size ASC":

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -367,3 +367,75 @@ func TestAttachVerificationProgress(t *testing.T) {
 		t.Error("GetQueueItems did not return completed item a")
 	}
 }
+
+// TestGetQueueItems_PendingFilterSortsByCreated reproduces issue #245 (1):
+// filtering by status=pending with the default "created" sort produced
+// "no such column: created_at" because the goqite table names that column
+// "created". The endpoint returned HTTP 500 and the dashboard queue was empty.
+func TestGetQueueItems_PendingFilterSortsByCreated(t *testing.T) {
+	q := newTestQueue(t)
+	ctx := context.Background()
+
+	if err := q.AddFile(ctx, "/tmp/pending-a.bin", 10); err != nil {
+		t.Fatalf("AddFile a: %v", err)
+	}
+	if err := q.AddFile(ctx, "/tmp/pending-b.bin", 20); err != nil {
+		t.Fatalf("AddFile b: %v", err)
+	}
+
+	for _, order := range []string{"", "asc", "desc"} {
+		result, err := q.GetQueueItems(PaginationParams{Status: "pending", SortBy: "created", Order: order, Page: 1, Limit: 25})
+		if err != nil {
+			t.Fatalf("GetQueueItems(status=pending, order=%q): %v", order, err)
+		}
+		if result.TotalItems != 2 || len(result.Items) != 2 {
+			t.Fatalf("order=%q: got total=%d items=%d, want 2/2", order, result.TotalItems, len(result.Items))
+		}
+		for _, item := range result.Items {
+			if item.Status != StatusPending {
+				t.Errorf("order=%q: item %s status=%q, want pending", order, item.Path, item.Status)
+			}
+		}
+	}
+}
+
+// TestGetQueueItems_StatusSortPagesAreContiguous guards the offset arithmetic
+// in getMergedItemsByStatus. When a page offset exceeds a status bucket, the
+// offset must shrink by that bucket's total size, not by the (empty) page it
+// returned, otherwise items at the bucket boundary are silently skipped.
+func TestGetQueueItems_StatusSortPagesAreContiguous(t *testing.T) {
+	q := newTestQueue(t)
+	ctx := context.Background()
+
+	// One running item, three pending items.
+	if err := q.AddFile(ctx, "/tmp/running.bin", 1); err != nil {
+		t.Fatalf("AddFile running: %v", err)
+	}
+	if msg, _, err := q.ReceiveFile(ctx); err != nil || msg == nil {
+		t.Fatalf("ReceiveFile: msg=%v err=%v", msg, err)
+	}
+	for _, name := range []string{"p1", "p2", "p3"} {
+		if err := q.AddFile(ctx, "/tmp/"+name+".bin", 1); err != nil {
+			t.Fatalf("AddFile %s: %v", name, err)
+		}
+	}
+
+	seen := map[string]int{}
+	for page := 1; page <= 2; page++ {
+		res, err := q.GetQueueItems(PaginationParams{SortBy: "status", Order: "desc", Page: page, Limit: 2})
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		if len(res.Items) != 2 {
+			t.Fatalf("page %d: got %d items, want 2 (%+v)", page, len(res.Items), res.Items)
+		}
+		for _, it := range res.Items {
+			seen[it.Path]++
+		}
+	}
+	for _, path := range []string{"/tmp/running.bin", "/tmp/p1.bin", "/tmp/p2.bin", "/tmp/p3.bin"} {
+		if seen[path] != 1 {
+			t.Errorf("%s appeared %d times across pages, want exactly once", path, seen[path])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Part 1 of a stacked series addressing #245 (and related stuck-upload reports in #168/#198).

- **Bug** (#245 item 1): filtering the queue by `status=pending` with the default `created` sort ran `ORDER BY created_at` against the `goqite` table, whose column is named `created`. Result: `no such column: created_at`, HTTP 500, empty dashboard queue.
- **Fix**: map the `created` sort key to `created` in the pending-only query (the merged union query already aliased it correctly).
- **Also**: `getMergedItemsByStatus` reduced the page offset by the size of the page a status bucket *returned* rather than the bucket's total size, so items at bucket boundaries were skipped (page 2 could come back empty). Offsets are now consumed against per-bucket counts.

## Test plan
- [x] `TestGetQueueItems_PendingFilterSortsByCreated` fails on main with `no such column: created_at`, passes here
- [x] `TestGetQueueItems_StatusSortPagesAreContiguous` fails on main (page 2 returns 0 items), passes here
- [x] `go test ./internal/queue/`, `go vet`, `golangci-lint run` clean

Stack: **this PR** → #248 → #249