### PR TITLE
fix(pausable): Resume woke only one blocked waiter, leaving jobs stuck

### DIFF
--- a/internal/pausable/context.go
+++ b/internal/pausable/context.go
@@ -13,18 +13,20 @@ const pausableContextKey contextKey = iota
 
 // Context wraps a context.Context and allows pausing/resuming operations
 type Context struct {
-	parent  context.Context
-	paused  bool
-	pauseCh chan struct{}
-	mu      sync.RWMutex
+	parent context.Context
+	paused bool
+	// resumeCh is created on Pause and closed on Resume. Closing broadcasts
+	// to every goroutine blocked in CheckPause; a single token would wake only
+	// one of them and leave the rest parked forever.
+	resumeCh chan struct{}
+	mu       sync.RWMutex
 }
 
 // NewContext creates a new pausable context that stores itself in the context chain
 func NewContext(parent context.Context) *Context {
 	pc := &Context{
-		parent:  parent,
-		paused:  false,
-		pauseCh: make(chan struct{}, 1),
+		parent: parent,
+		paused: false,
 	}
 
 	// Store reference to self in the context chain
@@ -60,42 +62,36 @@ func (pc *Context) Pause() {
 
 	if !pc.paused {
 		pc.paused = true
-		// Clear the resume channel
-		select {
-		case <-pc.pauseCh:
-		default:
-		}
+		pc.resumeCh = make(chan struct{})
 	}
 }
 
-// Resume resumes the context
+// Resume resumes the context and wakes every operation blocked in CheckPause
 func (pc *Context) Resume() {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
 	if pc.paused {
 		pc.paused = false
-		// Signal resume to all waiting operations
-		select {
-		case pc.pauseCh <- struct{}{}:
-		default:
-		}
+		close(pc.resumeCh)
+		pc.resumeCh = nil
 	}
 }
 
 // CheckPause blocks if the context is paused until it's resumed or the parent context is canceled
 func (pc *Context) CheckPause() error {
 	pc.mu.RLock()
-	paused := pc.paused
+	paused, resumeCh := pc.paused, pc.resumeCh
 	pc.mu.RUnlock()
 
 	if !paused {
 		return nil
 	}
 
-	// Wait for resume or parent context cancellation
+	// resumeCh was captured under the lock, so a Resume that races with this
+	// call closes the same channel we wait on and the wakeup cannot be lost.
 	select {
-	case <-pc.pauseCh:
+	case <-resumeCh:
 		return nil
 	case <-pc.parent.Done():
 		return pc.parent.Err()

--- a/internal/pausable/context_test.go
+++ b/internal/pausable/context_test.go
@@ -2,6 +2,7 @@ package pausable
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -40,7 +41,7 @@ func TestCheckPause(t *testing.T) {
 
 	// Test CheckPause when paused and then resumed
 	pausableCtx.Pause()
-	
+
 	// Resume in a goroutine after a short delay
 	go func() {
 		time.Sleep(50 * time.Millisecond)
@@ -65,7 +66,7 @@ func TestCheckPauseWithCanceledContext(t *testing.T) {
 	pausableCtx := NewContext(ctx)
 
 	pausableCtx.Pause()
-	
+
 	// Cancel the parent context
 	cancel()
 
@@ -135,5 +136,72 @@ func TestCheckPauseFunction(t *testing.T) {
 	}
 	if duration < 40*time.Millisecond {
 		t.Error("CheckPause should have blocked for some time")
+	}
+}
+
+// TestResumeWakesAllWaiters guards against the lost-wakeup bug where Resume
+// delivered a single token, so only one of the goroutines blocked in
+// CheckPause continued and the rest (upload workers, post loop) stayed
+// parked forever, leaving the job "running" with no progress.
+func TestResumeWakesAllWaiters(t *testing.T) {
+	pc := NewContext(context.Background())
+	pc.Pause()
+
+	const waiters = 16
+	var started, finished sync.WaitGroup
+	started.Add(waiters)
+	finished.Add(waiters)
+	errs := make(chan error, waiters)
+	for i := 0; i < waiters; i++ {
+		go func() {
+			defer finished.Done()
+			started.Done()
+			errs <- pc.CheckPause()
+		}()
+	}
+	started.Wait()
+	time.Sleep(20 * time.Millisecond) // let every goroutine reach the blocking select
+
+	pc.Resume()
+
+	done := make(chan struct{})
+	go func() { finished.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("not all CheckPause waiters returned after a single Resume")
+	}
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("CheckPause returned error after resume: %v", err)
+		}
+	}
+}
+
+// TestPauseAfterResumeBlocksAgain ensures a Resume with no waiters does not
+// leave a stale wakeup that lets the next CheckPause slip through a pause.
+func TestPauseAfterResumeBlocksAgain(t *testing.T) {
+	pc := NewContext(context.Background())
+	pc.Pause()
+	pc.Resume()
+	pc.Pause()
+
+	returned := make(chan struct{})
+	go func() {
+		_ = pc.CheckPause()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		t.Fatal("CheckPause returned while paused")
+	case <-time.After(50 * time.Millisecond):
+	}
+	pc.Resume()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("CheckPause did not return after Resume")
 	}
 }


### PR DESCRIPTION
## Summary
Part 2 of the stacked series for #245 / #168. **Stacked on #247** — review only the last commit.

- **Bug**: `pausable.Context.Resume` pushed one token into a buffered(1) channel. Every upload worker in the shared pool plus the post loop block in `CheckPause` on the same context, so after pause → resume only one of them woke up. Remaining articles never posted, the job showed "running" forever with no log output, and the row never left `in_progress_items` (the stuck-running symptom in #245 items 2/3 and #168).
- **Fix**: Pause creates a fresh channel; Resume closes it (broadcast). `CheckPause` snapshots the channel under the lock before blocking, so a racing Resume closes the same channel and no wakeup is lost. A Resume with no waiters can no longer leave a stale token that lets the next pause be skipped.

## Test plan
- [x] `TestResumeWakesAllWaiters` (16 waiters, one Resume) fails on main (times out), passes here
- [x] `TestPauseAfterResumeBlocksAgain` passes
- [x] `go test -race ./internal/pausable/ ./internal/poster/ ./internal/processor/` clean
- [x] `go vet`, `golangci-lint run` clean

Stack: #247 → **this PR** → #249