### PR TITLE
fix(poster): resumed/retried uploads produced incomplete or malformed NZBs

### DIFF
--- a/internal/poster/poster.go
+++ b/internal/poster/poster.go
@@ -1234,12 +1234,33 @@ func (p *poster) checkLoop(ctx context.Context, checkQueue chan *Post, postQueue
 // STATs each to skip those already present on the server, and enqueues only the
 // missing ones. It never rewrites the manifest. If every article is already
 // present the post is enqueued with no articles and completes immediately.
-func (p *poster) addRecoveredPost(ctx context.Context, filePath string, file *os.File, fileInfo os.FileInfo, recs []manifest.ArticleRecord, wg *sync.WaitGroup, failedPosts *atomic.Int64, postQueue chan<- *Post, postsInFlight *sync.WaitGroup) error {
+func (p *poster) addRecoveredPost(ctx context.Context, filePath string, fileNumber int, file *os.File, fileInfo os.FileInfo, recs []manifest.ArticleRecord, wg *sync.WaitGroup, failedPosts *atomic.Int64, postQueue chan<- *Post, nzbGen nzb.NZBGenerator, postsInFlight *sync.WaitGroup) error {
+	// The manifest does not carry OriginalName/FileNumber, but the NZB
+	// generator groups segments by OriginalName and orders files by
+	// FileNumber; without them every recovered file collapses into one
+	// nameless NZB entry.
+	originalName := filepath.Base(filePath)
 	all := make([]*article.Article, 0, len(recs))
 	for _, r := range recs {
-		all = append(all, articleFromRecord(r))
+		art := articleFromRecord(r)
+		art.OriginalName = originalName
+		art.FileNumber = fileNumber
+		all = append(all, art)
 	}
 	missing := p.filterMissing(ctx, all)
+
+	// Articles already on the server are not re-posted, but they are still
+	// part of the upload and must appear in the NZB. Only the ones posted now
+	// are added by processPost.
+	isMissing := make(map[string]struct{}, len(missing))
+	for _, art := range missing {
+		isMissing[art.MessageID] = struct{}{}
+	}
+	for _, art := range all {
+		if _, ok := isMissing[art.MessageID]; !ok {
+			nzbGen.AddArticle(art)
+		}
+	}
 
 	slog.InfoContext(ctx, "Recovered manifest; re-posting only missing articles",
 		"file", filePath, "total", len(all), "missing", len(missing))
@@ -1333,7 +1354,7 @@ func (p *poster) addPost(ctx context.Context, filePath string, displayName strin
 			slog.WarnContext(ctx, "Failed to read existing manifest; regenerating", "file", filePath, "error", err)
 		} else if ok {
 			owned = false // addRecoveredPost enqueues or closes the file itself
-			return p.addRecoveredPost(ctx, filePath, file, fileInfo, recs, wg, failedPosts, postQueue, postsInFlight)
+			return p.addRecoveredPost(ctx, filePath, fileNumber, file, fileInfo, recs, wg, failedPosts, postQueue, nzbGen, postsInFlight)
 		}
 	}
 

--- a/internal/poster/recovery_nzb_test.go
+++ b/internal/poster/recovery_nzb_test.go
@@ -1,0 +1,147 @@
+package poster
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/javi11/nntppool/v4"
+	"go.uber.org/mock/gomock"
+
+	"github.com/javi11/postie/internal/article"
+	"github.com/javi11/postie/internal/manifest"
+	"github.com/javi11/postie/internal/mocks"
+)
+
+// existingManifestSink reports a pre-recorded manifest for every file so the
+// poster takes the recovery path (retry after failure or restart).
+type existingManifestSink struct {
+	recs []manifest.ArticleRecord
+}
+
+func (s *existingManifestSink) RecordFile(context.Context, string, []*article.Article) error {
+	return nil
+}
+
+func (s *existingManifestSink) ExistingArticles(context.Context, string) ([]manifest.ArticleRecord, bool, error) {
+	return s.recs, len(s.recs) > 0, nil
+}
+
+func recoveryRecords(filePath string, content string) []manifest.ArticleRecord {
+	half := int64(len(content) / 2)
+	mk := func(i int, off, size int64) manifest.ArticleRecord {
+		return manifest.ArticleRecord{
+			Index: i, SourcePath: filePath, FileRole: manifest.RoleOriginal,
+			Offset: off, BodySize: uint64(size), MessageID: "rec-" + string(rune('a'+i)),
+			Subject: "subj", OriginalSubject: "osubj", From: "x@y", Groups: []string{"alt.test"},
+			FileName: "obf", PartNumber: i + 1, TotalParts: 2, FileSize: int64(len(content)),
+		}
+	}
+	return []manifest.ArticleRecord{mk(0, 0, half), mk(1, half, int64(len(content))-half)}
+}
+
+// runRecoveredPost posts testFile through the recovery path with the given set
+// of message IDs reported missing by STAT, and returns the articles the NZB
+// generator received.
+func runRecoveredPost(t *testing.T, missing map[string]error) (string, []*article.Article, error) {
+	t.Helper()
+	content := strings.Repeat("recovered data ", 200)
+	testFile := createTestFile(t, content)
+	t.Cleanup(func() { _ = os.Remove(testFile) })
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockPool := mocks.NewMockNNTPClient(ctrl)
+	mockPool.EXPECT().Stats().Return(nntppool.ClientStats{
+		Providers: []nntppool.ProviderStats{{MaxConnections: 2}},
+	}).AnyTimes()
+	mockPool.EXPECT().StatMany(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(statManyStub(missing)).AnyTimes()
+	mockPool.EXPECT().PostYenc(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&nntppool.PostResult{}, nil).Times(len(missing))
+
+	var mu sync.Mutex
+	var added []*article.Article
+	nzbGen := mocks.NewMockNZBGenerator(ctrl)
+	nzbGen.EXPECT().AddArticle(gomock.Any()).DoAndReturn(func(a *article.Article) {
+		mu.Lock()
+		defer mu.Unlock()
+		added = append(added, a)
+	}).AnyTimes()
+
+	mockJobProgress := mocks.NewMockJobProgress(ctrl)
+	mockProgress := mocks.NewMockProgress(ctrl)
+	mockJobProgress.EXPECT().AddProgress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockProgress).AnyTimes()
+	mockJobProgress.EXPECT().FinishProgress(gomock.Any()).AnyTimes()
+	mockProgress.EXPECT().UpdateProgress(gomock.Any()).AnyTimes()
+	mockProgress.EXPECT().GetID().Return(uuid.New()).AnyTimes()
+
+	checkCfg := createTestPostCheckConfig()
+	disabled := false
+	checkCfg.Enabled = &disabled
+
+	p := &poster{
+		cfg:          createTestConfig(),
+		checkCfg:     checkCfg,
+		uploadPool:   mockPool,
+		verifyPool:   mockPool,
+		stats:        &Stats{StartTime: time.Now()},
+		jobProgress:  mockJobProgress,
+		manifestSink: &existingManifestSink{recs: recoveryRecords(testFile, content)},
+	}
+	err := p.Post(context.Background(), []string{testFile}, "", nzbGen)
+	p.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	return testFile, added, err
+}
+
+func assertNZBHasBothSegments(t *testing.T, testFile string, added []*article.Article) {
+	t.Helper()
+	if len(added) != 2 {
+		t.Fatalf("NZB received %d articles, want 2 (every planned segment, posted or already present)", len(added))
+	}
+	ids := map[string]bool{}
+	for _, a := range added {
+		ids[a.MessageID] = true
+		if a.OriginalName != filepath.Base(testFile) {
+			t.Errorf("article %s OriginalName=%q, want %q (NZB groups segments by it)", a.MessageID, a.OriginalName, filepath.Base(testFile))
+		}
+		if a.FileNumber != 1 {
+			t.Errorf("article %s FileNumber=%d, want 1", a.MessageID, a.FileNumber)
+		}
+	}
+	if !ids["rec-a"] || !ids["rec-b"] {
+		t.Errorf("NZB is missing segments: got %v", ids)
+	}
+}
+
+// TestRecoveredPost_AllPresentStillFillsNZB: after a retry or restart every
+// article may already be on the server. Nothing needs re-posting, but the NZB
+// must still list all segments or the output is unusable.
+func TestRecoveredPost_AllPresentStillFillsNZB(t *testing.T) {
+	testFile, added, err := runRecoveredPost(t, nil)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	assertNZBHasBothSegments(t, testFile, added)
+}
+
+// TestRecoveredPost_PartiallyPresentFillsNZB: only the missing article is
+// re-posted, but the NZB must contain both the re-posted and the already
+// present segment.
+func TestRecoveredPost_PartiallyPresentFillsNZB(t *testing.T) {
+	testFile, added, err := runRecoveredPost(t, map[string]error{"rec-b": errors.New("430 no such article")})
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	assertNZBHasBothSegments(t, testFile, added)
+}


### PR DESCRIPTION
## Summary
Part 3 of the stacked series for #245 / #168. **Stacked on #248** — review only the last commit.

- **Bug**: on retry (same `TransferID` is re-queued) or crash recovery the poster reuses the manifest, STATs the planned articles and re-posts only the missing ones. But only articles posted *in that attempt* were handed to the NZB generator. Already-present segments were dropped from the NZB; when every segment was already present the generator had zero articles and the job failed with `no articles found` (no NZB written — the #245 item 2 symptom after the restart re-upload).
- **Also**: `articleFromRecord` does not populate `OriginalName`/`FileNumber` (the manifest doesn't store them). The NZB generator groups segments by `OriginalName` and orders files by `FileNumber`, so every recovered file collapsed into one nameless `<file>` entry — the malformed NZB reports in #168.
- **Fix**: `addRecoveredPost` now receives the NZB generator and file position, restores `OriginalName` (basename of the source path) and `FileNumber` on the rebuilt articles, and registers the already-present articles with the generator before queuing the re-post of the missing ones.

## Test plan
- [x] `TestRecoveredPost_AllPresentStillFillsNZB` fails on main (0 articles in NZB), passes here
- [x] `TestRecoveredPost_PartiallyPresentFillsNZB` fails on main (1 of 2 articles), passes here; asserts `OriginalName`/`FileNumber` are set
- [x] `go test -race ./internal/poster/` clean, `go vet` clean (2 `errcheck` lint hits in `stale_conn_test.go` are pre-existing on main)

Stack: #247 → #248 → **this PR**