### PR TITLE
fix(postie): PAR2 files were deleted before durable verification could re-post them

### DIFF
--- a/pkg/postie/par2_retention_test.go
+++ b/pkg/postie/par2_retention_test.go
@@ -1,0 +1,119 @@
+package postie
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/postie/internal/transferwriter"
+	"github.com/javi11/postie/pkg/fileinfo"
+)
+
+// par2InDir is a PAR2 executor that always materialises a set in dir, mirroring
+// the default behaviour (no output dir configured → temp/source dir).
+type par2InDir struct{ dir string }
+
+func (m *par2InDir) create(setName string) ([]string, error) {
+	paths := []string{
+		filepath.Join(m.dir, setName+".par2"),
+		filepath.Join(m.dir, setName+".vol0+1.par2"),
+	}
+	for _, p := range paths {
+		if err := os.WriteFile(p, []byte("par2"), 0644); err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+func (m *par2InDir) Create(_ context.Context, files []fileinfo.FileInfo) ([]string, error) {
+	return m.create(filepath.Base(files[0].Path))
+}
+
+func (m *par2InDir) CreateInDirectory(_ context.Context, files []fileinfo.FileInfo, _ string) ([]string, error) {
+	return m.create(filepath.Base(files[0].Path))
+}
+
+func (m *par2InDir) CreateSet(_ context.Context, _ []fileinfo.FileInfo, _, setName, _ string) ([]string, error) {
+	return m.create(setName)
+}
+
+func par2FilesLeft(t *testing.T, dir string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.par2"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	return len(matches)
+}
+
+type postFn func(p *Postie, ctx context.Context, files []fileinfo.FileInfo, root, out string) error
+
+var postPaths = map[string]postFn{
+	"postFolder": func(p *Postie, ctx context.Context, files []fileinfo.FileInfo, root, out string) error {
+		_, err := p.postFolder(ctx, files, root, out)
+		return err
+	},
+	"post": func(p *Postie, ctx context.Context, files []fileinfo.FileInfo, root, out string) error {
+		_, err := p.post(ctx, files[0], root, out)
+		return err
+	},
+	"postInParallel": func(p *Postie, ctx context.Context, files []fileinfo.FileInfo, root, out string) error {
+		_, err := p.postInParallel(ctx, files[0], root, out)
+		return err
+	},
+}
+
+// TestPar2RetainedUntilVerifiedInDurableMode: with maintain_par2_files off the
+// generated PAR2 set used to be deleted as soon as posting finished. In durable
+// mode verification runs later in the background and may need to re-post PAR2
+// articles from those files, and the transfer cleaner already removes them
+// after verification. Deleting them eagerly turns any lost PAR2 article into a
+// permanent verification failure for the whole transfer.
+func TestPar2RetainedUntilVerifiedInDurableMode(t *testing.T) {
+	for name, run := range postPaths {
+		for _, waitForPar2 := range []bool{true, false} {
+			t.Run(name, func(t *testing.T) {
+				root := t.TempDir()
+				files, cleanup := makeSourceFiles(t, root, "Folder", "video.mkv")
+				defer cleanup()
+				par2Dir := t.TempDir()
+
+				p := newTestPostie(nil, waitForPar2, false)
+				p.par2runner = &par2InDir{dir: par2Dir}
+				p.recorder = transferwriter.New("transfer-1", t.TempDir(), nil)
+
+				if err := run(p, context.Background(), files, root, t.TempDir()); err != nil {
+					t.Fatalf("%s(waitForPar2=%v): %v", name, waitForPar2, err)
+				}
+				if n := par2FilesLeft(t, par2Dir); n != 2 {
+					t.Errorf("%s(waitForPar2=%v): %d PAR2 files left, want 2 retained for verification", name, waitForPar2, n)
+				}
+			})
+		}
+	}
+}
+
+// TestPar2CleanedAfterPostInStandaloneMode keeps the legacy behaviour: without
+// a durable recorder nothing else will remove the temporary PAR2 set.
+func TestPar2CleanedAfterPostInStandaloneMode(t *testing.T) {
+	for name, run := range postPaths {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			files, cleanup := makeSourceFiles(t, root, "Folder", "video.mkv")
+			defer cleanup()
+			par2Dir := t.TempDir()
+
+			p := newTestPostie(nil, true, false)
+			p.par2runner = &par2InDir{dir: par2Dir}
+
+			if err := run(p, context.Background(), files, root, t.TempDir()); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if n := par2FilesLeft(t, par2Dir); n != 0 {
+				t.Errorf("%s: %d PAR2 files left, want 0 in standalone mode", name, n)
+			}
+		})
+	}
+}

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -145,6 +145,18 @@ func NewWithRuntime(
 	}, nil
 }
 
+// removePar2AfterPost reports whether generated PAR2 files should be deleted as
+// soon as posting succeeds. Only in standalone mode with maintain_par2_files
+// off: in durable mode the background verification may still need to re-post
+// PAR2 articles from those files, and the transfer cleaner removes them once
+// the transfer is verified.
+func (p *Postie) removePar2AfterPost() bool {
+	if p.recorder != nil {
+		return false
+	}
+	return p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files
+}
+
 // completeTransferUpload marks the transfer's files uploaded so the durable
 // verification service can verify them, scheduling the first check after the
 // configured propagation delay. No-op in standalone mode (no recorder).
@@ -324,10 +336,7 @@ func (p *Postie) postInParallel(
 			return
 		}
 
-		// Only clean up if maintain_par2_files is disabled
-		// If enabled, files are already in output directory - no action needed
-		if p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files {
-			// Clean up PAR2 files when maintain_par2_files is disabled (default)
+		if p.removePar2AfterPost() {
 			for _, path := range createdPar2Paths {
 				safeRemoveFile(ctx, path)
 			}
@@ -434,10 +443,7 @@ func (p *Postie) post(
 			return
 		}
 
-		// Only clean up if maintain_par2_files is disabled
-		// If enabled, files are already in output directory - no action needed
-		if p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files {
-			// Clean up PAR2 files when maintain_par2_files is disabled (default)
+		if p.removePar2AfterPost() {
 			for _, path := range createdPar2Paths {
 				safeRemoveFile(ctx, path)
 			}
@@ -543,10 +549,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 			return
 		}
 
-		// Only clean up if maintain_par2_files is disabled
-		// If enabled, files are already in output directory - no action needed
-		if p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files {
-			// Clean up PAR2 files when maintain_par2_files is disabled (default)
+		if p.removePar2AfterPost() {
 			for _, path := range createdPar2Paths {
 				safeRemoveFile(ctx, path)
 			}


### PR DESCRIPTION
## Summary
Part 4 of the stacked series. **Stacked on #249** — review only the last commit.

- **Bug**: with `maintain_par2_files: false`, `post`, `postInParallel` and `postFolder` all delete the generated PAR2 set right after posting. In durable mode verification happens later and re-posts missing articles by reading the body back from the source file (`Reposter.Repost`). For PAR2 articles that file is already gone, so the failure falls back to STAT-only rechecks, exhausts them, and the *entire* transfer is marked `verification_failed` (originals retained, no cleanup, item shows failed) even though the payload is recoverable. The verification service even has a code comment anticipating "a temp PAR2 already cleaned up".
- **Fix**: `removePar2AfterPost()` returns false whenever a durable recorder is attached. The transfer cleaner already removes generated PAR2 files after verification (unless maintained), so nothing leaks. Standalone mode is unchanged.

## Test plan
- [x] `TestPar2RetainedUntilVerifiedInDurableMode` (3 post paths × wait_for_par2 on/off) fails on the base branch, passes here
- [x] `TestPar2CleanedAfterPostInStandaloneMode` guards the legacy behaviour
- [x] `go test -race ./pkg/postie/`, `go vet` clean (the `errcheck`/`unused` lint hits in this package pre-exist on main)

Stack: #247 → #248 → #249 → **this PR** → #251 → #252