### PR TITLE
fix(queue): removing a completed item left its durable transfer alive (originals could be deleted later)

### DIFF
--- a/internal/backend/queue.go
+++ b/internal/backend/queue.go
@@ -16,16 +16,16 @@ import (
 
 // QueueItem represents a queue item for the frontend - matches queue.QueueItem
 type QueueItem struct {
-	ID           string     `json:"id"`
-	Path         string     `json:"path"`
-	FileName     string     `json:"fileName"`
-	Size         int64      `json:"size"`
-	Status       string     `json:"status"`
-	RetryCount   int        `json:"retryCount"`
-	Priority     int        `json:"priority"`
-	ErrorMessage *string    `json:"errorMessage"`
-	CreatedAt    time.Time  `json:"createdAt"`
-	UpdatedAt    time.Time  `json:"updatedAt"`
+	ID                 string     `json:"id"`
+	Path               string     `json:"path"`
+	FileName           string     `json:"fileName"`
+	Size               int64      `json:"size"`
+	Status             string     `json:"status"`
+	RetryCount         int        `json:"retryCount"`
+	Priority           int        `json:"priority"`
+	ErrorMessage       *string    `json:"errorMessage"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	UpdatedAt          time.Time  `json:"updatedAt"`
 	CompletedAt        *time.Time `json:"completedAt"`
 	NzbPath            *string    `json:"nzbPath"`
 	VerificationStatus *string    `json:"verificationStatus"`
@@ -213,16 +213,16 @@ func (a *App) GetQueueItems(params PaginationParams) (*PaginatedQueueResult, err
 	var items []QueueItem
 	for _, queueItem := range result.Items {
 		item := QueueItem{
-			ID:           queueItem.ID,
-			Path:         queueItem.Path,
-			FileName:     queueItem.FileName,
-			Size:         queueItem.Size,
-			Status:       queueItem.Status,
-			RetryCount:   queueItem.RetryCount,
-			Priority:     queueItem.Priority,
-			ErrorMessage: queueItem.ErrorMessage,
-			CreatedAt:    queueItem.CreatedAt,
-			UpdatedAt:    queueItem.UpdatedAt,
+			ID:                 queueItem.ID,
+			Path:               queueItem.Path,
+			FileName:           queueItem.FileName,
+			Size:               queueItem.Size,
+			Status:             queueItem.Status,
+			RetryCount:         queueItem.RetryCount,
+			Priority:           queueItem.Priority,
+			ErrorMessage:       queueItem.ErrorMessage,
+			CreatedAt:          queueItem.CreatedAt,
+			UpdatedAt:          queueItem.UpdatedAt,
 			CompletedAt:        queueItem.CompletedAt,
 			NzbPath:            queueItem.NzbPath,
 			VerificationStatus: queueItem.VerificationStatus,
@@ -247,6 +247,14 @@ func (a *App) GetQueueItems(params PaginationParams) (*PaginatedQueueResult, err
 func (a *App) RemoveFromQueue(id string) error {
 	if a.queue == nil {
 		return fmt.Errorf("queue not initialized")
+	}
+
+	// A running job keeps uploading after its tracking row is deleted and
+	// then re-creates a completed row; stop it first so removal is final.
+	if a.processor != nil && a.processor.GetRunningJobs()[id] {
+		if err := a.processor.CancelJob(id); err != nil {
+			slog.Warn("Failed to cancel running job before removal", "id", id, "error", err)
+		}
 	}
 
 	err := a.queue.RemoveFromQueue(id)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1481,6 +1481,10 @@ func (q *Queue) RemoveCompletedItem(id string) error {
 		return fmt.Errorf("failed to delete pending article checks: %w", err)
 	}
 
+	if err := q.detachTransfers("completed_item_id = ?", id); err != nil {
+		return err
+	}
+
 	// Delete the database record
 	_, err = q.db.Exec("DELETE FROM completed_items WHERE id = ?", id)
 	if err != nil {
@@ -1493,6 +1497,59 @@ func (q *Queue) RemoveCompletedItem(id string) error {
 		// Don't return error here as the database record is already deleted
 	}
 
+	return nil
+}
+
+// detachTransfers removes the durable transfer rows (and their verification
+// failures and manifests) selected by the transfer_files WHERE clause. Called
+// when the completed items they belong to are removed by the user: the
+// background verification must stop for them, and above all the
+// post-verification cleaner must never delete originals for an upload whose
+// NZB the user has just thrown away.
+func (q *Queue) detachTransfers(where string, arg any) error {
+	var args []any
+	if arg != nil {
+		args = append(args, arg)
+	}
+
+	rows, err := q.db.Query("SELECT DISTINCT transfer_id, manifest_path FROM transfer_files WHERE "+where, args...)
+	if err != nil {
+		return fmt.Errorf("failed to list transfer files: %w", err)
+	}
+	transferIDs := make(map[string]struct{})
+	var manifests []string
+	for rows.Next() {
+		var transferID, manifestPath string
+		if err := rows.Scan(&transferID, &manifestPath); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("failed to scan transfer file: %w", err)
+		}
+		transferIDs[transferID] = struct{}{}
+		manifests = append(manifests, manifestPath)
+	}
+	// Close before writing: with a single SQLite connection an open cursor
+	// would block the deletes below.
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close transfer files cursor: %w", err)
+	}
+
+	for transferID := range transferIDs {
+		if _, err := q.db.Exec("DELETE FROM verification_failures WHERE transfer_id = ?", transferID); err != nil {
+			return fmt.Errorf("failed to delete verification failures for %s: %w", transferID, err)
+		}
+		if _, err := q.db.Exec("DELETE FROM transfer_files WHERE transfer_id = ?", transferID); err != nil {
+			return fmt.Errorf("failed to delete transfer files for %s: %w", transferID, err)
+		}
+	}
+
+	for _, path := range manifests {
+		if path == "" {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Warn("Failed to remove manifest of detached transfer", "path", path, "error", err)
+		}
+	}
 	return nil
 }
 
@@ -1532,6 +1589,10 @@ func (q *Queue) ClearQueue() error {
 	// Clear pending article checks first (FK constraint)
 	_, err = q.db.Exec("DELETE FROM pending_article_checks")
 	if err != nil {
+		return err
+	}
+
+	if err := q.detachTransfers("completed_item_id IS NOT NULL", nil); err != nil {
 		return err
 	}
 
@@ -1584,6 +1645,10 @@ func (q *Queue) ClearCompletedItems() error {
 	// Clear pending article checks first (FK constraint)
 	_, err = q.db.Exec("DELETE FROM pending_article_checks")
 	if err != nil {
+		return err
+	}
+
+	if err := q.detachTransfers("completed_item_id IS NOT NULL", nil); err != nil {
 		return err
 	}
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -438,4 +439,89 @@ func TestGetQueueItems_StatusSortPagesAreContiguous(t *testing.T) {
 			t.Errorf("%s appeared %d times across pages, want exactly once", path, seen[path])
 		}
 	}
+}
+
+// completeItemWithTransfer adds a file, completes it, and links a durable
+// transfer_files row (delete_original policy) plus a pending verification
+// failure to it, the state a durable upload is in right after posting.
+func completeItemWithTransfer(t *testing.T, q *Queue, path string) (itemID, manifestPath string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := q.AddFile(ctx, path, 10); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	msg, job, err := q.ReceiveFile(ctx)
+	if err != nil || msg == nil {
+		t.Fatalf("ReceiveFile: msg=%v err=%v", msg, err)
+	}
+	if err := q.CompleteFile(ctx, msg.ID, path+".nzb", job); err != nil {
+		t.Fatalf("CompleteFile: %v", err)
+	}
+	itemID = string(msg.ID)
+
+	manifestPath = filepath.Join(t.TempDir(), "manifest.jsonl.zst")
+	if err := os.WriteFile(manifestPath, []byte("m"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if _, err := q.db.Exec(`
+		INSERT INTO transfer_files (transfer_id, file_id, completed_item_id, manifest_path, source_path,
+		                            upload_state, verification_state, next_check_at, cleanup_policy)
+		VALUES (?, 'f1', ?, ?, ?, 'uploaded', 'uploaded', '2000-01-01T00:00:00.000Z', 'delete_original')`,
+		job.TransferID, itemID, manifestPath, path); err != nil {
+		t.Fatalf("insert transfer_files: %v", err)
+	}
+	if _, err := q.db.Exec(`
+		INSERT INTO verification_failures (transfer_id, file_id, article_index, message_id)
+		VALUES (?, 'f1', 0, 'mid-1')`, job.TransferID); err != nil {
+		t.Fatalf("insert verification_failures: %v", err)
+	}
+	return itemID, manifestPath
+}
+
+func assertTransferDetached(t *testing.T, q *Queue, itemID, manifestPath string) {
+	t.Helper()
+	if n := countRows(t, q, "transfer_files", "completed_item_id = ?", itemID); n != 0 {
+		t.Errorf("transfer_files rows for removed item: %d, want 0 (verification would keep running and could delete originals)", n)
+	}
+	if n := countRows(t, q, "verification_failures", ""); n != 0 {
+		t.Errorf("verification_failures rows left: %d, want 0", n)
+	}
+	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
+		t.Errorf("manifest %s still exists, want removed", manifestPath)
+	}
+}
+
+// TestRemoveCompletedItemDetachesTransfer: a user removing a completed item
+// (deleting its NZB) must also stop background verification for it. Otherwise
+// the verification service keeps STAT-ing, and once verified the cleaner
+// deletes the originals under the delete_original policy — leaving the user
+// with neither the NZB nor the source files.
+func TestRemoveCompletedItemDetachesTransfer(t *testing.T) {
+	q := newTestQueue(t)
+	itemID, manifestPath := completeItemWithTransfer(t, q, "/tmp/removed.bin")
+
+	if err := q.RemoveFromQueue(itemID); err != nil {
+		t.Fatalf("RemoveFromQueue: %v", err)
+	}
+	assertTransferDetached(t, q, itemID, manifestPath)
+}
+
+func TestClearQueueDetachesTransfers(t *testing.T) {
+	q := newTestQueue(t)
+	itemID, manifestPath := completeItemWithTransfer(t, q, "/tmp/cleared.bin")
+
+	if err := q.ClearQueue(); err != nil {
+		t.Fatalf("ClearQueue: %v", err)
+	}
+	assertTransferDetached(t, q, itemID, manifestPath)
+}
+
+func TestClearCompletedItemsDetachesTransfers(t *testing.T) {
+	q := newTestQueue(t)
+	itemID, manifestPath := completeItemWithTransfer(t, q, "/tmp/cleared-completed.bin")
+
+	if err := q.ClearCompletedItems(); err != nil {
+		t.Fatalf("ClearCompletedItems: %v", err)
+	}
+	assertTransferDetached(t, q, itemID, manifestPath)
 }


### PR DESCRIPTION
## Summary
Part 5 of the stacked series. **Stacked on #250** — review only the last two commits.

- **Bug (data loss)**: `RemoveCompletedItem`, `ClearQueue` and `ClearCompletedItems` deleted the completed row and its NZB but left the `transfer_files` / `verification_failures` rows in place. The background verification kept working on the transfer, and once fully verified the transfer cleaner applied the recorded `delete_original` policy. A user who removed a just-finished upload (for example to re-do it) lost the NZB *and* the source files.
- **Fix**: a `detachTransfers` helper deletes the transfer rows, their verification failures and manifest files for the removed item(s). Verification finds nothing to do and the cleaner never runs for them. Rows with no `completed_item_id` (uploads still in progress) are untouched.
- **Also**: `App.RemoveFromQueue` on a *running* item only deleted its `in_progress_items` row; the upload kept going and re-created a completed row on finish. It now cancels the running job first.

## Test plan
- [x] `TestRemoveCompletedItemDetachesTransfer`, `TestClearQueueDetachesTransfers`, `TestClearCompletedItemsDetachesTransfers` fail on the base branch, pass here
- [x] `go test -race ./internal/queue/`, `go vet`, `golangci-lint run ./internal/queue/...` clean
- [ ] The running-job cancel glue in `internal/backend` has no unit test (the package has none); the cancel path itself is covered by processor tests

Stack: #247 → #248 → #249 → #250 → **this PR** → #252