### PR TITLE
fix(watcher): one unreadable entry aborted the whole watch-folder scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/klauspost/compress v1.18.2
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/mnightingale/rapidyenc v0.0.0-20251128204712-7aafef1eaf1c
-	github.com/opencontainers/selinux v1.13.1
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sourcegraph/conc v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
-github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/javi11/postie/internal/config"
 	"github.com/javi11/postie/internal/queue"
-	"github.com/opencontainers/selinux/pkg/pwalkdir"
 )
 
 // WatcherScheduleInfo represents the schedule configuration
@@ -157,33 +156,7 @@ func (w *Watcher) scanDirectory(ctx context.Context) error {
 	}
 
 	// Process all files in directory (traditional mode - one NZB per file)
-	return pwalkdir.Walk(w.watchFolder, func(path string, dir fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Skip directories
-		if dir.IsDir() {
-			return nil
-		}
-
-		// Check if the path is a symlink and skip if not following symlinks
-		if !w.cfg.FollowSymlinks {
-			isSymlinkFile, err := isSymlink(path)
-			if err != nil {
-				slog.DebugContext(ctx, "Error checking if path is symlink, skipping", "path", path, "error", err)
-				return nil
-			}
-			if isSymlinkFile {
-				slog.DebugContext(ctx, "Skipping symlink", "path", path)
-				return nil
-			}
-		}
-
-		info, err := dir.Info()
-		if err != nil {
-			return err
-		}
+	return w.walkFiles(ctx, func(path string, info os.FileInfo) error {
 
 		slog.DebugContext(ctx, "Processing file", "path", path, "size", info.Size(), "mod_time", info.ModTime())
 
@@ -237,33 +210,7 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 	var mapMutex sync.Mutex
 
 	// Walk the directory tree and collect files by folder
-	err := pwalkdir.Walk(w.watchFolder, func(path string, dir fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Skip directories
-		if dir.IsDir() {
-			return nil
-		}
-
-		// Check if the path is a symlink and skip if not following symlinks
-		if !w.cfg.FollowSymlinks {
-			isSymlinkFile, err := isSymlink(path)
-			if err != nil {
-				slog.DebugContext(ctx, "Error checking if path is symlink, skipping", "path", path, "error", err)
-				return nil
-			}
-			if isSymlinkFile {
-				slog.DebugContext(ctx, "Skipping symlink", "path", path)
-				return nil
-			}
-		}
-
-		info, err := dir.Info()
-		if err != nil {
-			return err
-		}
+	err := w.walkFiles(ctx, func(path string, info os.FileInfo) error {
 
 		// Skip files that don't meet criteria
 		if !w.shouldProcessFile(path, info) {
@@ -401,6 +348,51 @@ func (w *Watcher) scanDirectoryGroupByFolder(ctx context.Context) error {
 	return nil
 }
 
+// walkFiles calls fn for every regular file under the watch folder, skipping
+// directories and (unless configured otherwise) symlinks. An entry that cannot
+// be read or stat'ed is logged and skipped rather than aborting the whole scan:
+// a single permission-denied subfolder, or a file removed between listing and
+// stat, must not stop every other file from being imported. Only an unreadable
+// watch folder root is an error.
+func (w *Watcher) walkFiles(ctx context.Context, fn func(path string, info os.FileInfo) error) error {
+	return filepath.WalkDir(w.watchFolder, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			if path == w.watchFolder {
+				return err
+			}
+			slog.WarnContext(ctx, "Skipping unreadable entry in watch folder", "path", path, "error", err)
+			if entry != nil && entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		if !w.cfg.FollowSymlinks {
+			isSymlinkFile, err := isSymlink(path)
+			if err != nil {
+				slog.DebugContext(ctx, "Error checking if path is symlink, skipping", "path", path, "error", err)
+				return nil
+			}
+			if isSymlinkFile {
+				slog.DebugContext(ctx, "Skipping symlink", "path", path)
+				return nil
+			}
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			slog.DebugContext(ctx, "Skipping entry that could not be stat'ed", "path", path, "error", err)
+			return nil
+		}
+
+		return fn(path, info)
+	})
+}
+
 func (w *Watcher) shouldProcessFile(path string, info os.FileInfo) bool {
 	// Check minimum file size
 	if info.Size() < int64(w.cfg.MinFileSize) {
@@ -431,33 +423,7 @@ func (w *Watcher) shouldProcessFile(path string, info os.FileInfo) bool {
 func (w *Watcher) calculateDirectorySize(ctx context.Context) (int64, error) {
 	var totalSize int64
 
-	err := pwalkdir.Walk(w.watchFolder, func(path string, dir fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Skip directories
-		if dir.IsDir() {
-			return nil
-		}
-
-		// Check if the path is a symlink and skip if not following symlinks
-		if !w.cfg.FollowSymlinks {
-			isSymlinkFile, err := isSymlink(path)
-			if err != nil {
-				slog.DebugContext(ctx, "Error checking if path is symlink, skipping", "path", path, "error", err)
-				return nil
-			}
-			if isSymlinkFile {
-				slog.DebugContext(ctx, "Skipping symlink in size calculation", "path", path)
-				return nil
-			}
-		}
-
-		info, err := dir.Info()
-		if err != nil {
-			return err
-		}
+	err := w.walkFiles(ctx, func(path string, info os.FileInfo) error {
 
 		// Only count files that meet basic criteria (not ignore patterns and min file size)
 		if w.shouldCountFile(path, info) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1130,3 +1130,45 @@ func TestScan_JobsCarryWatcherInputFolder(t *testing.T) {
 		}
 	})
 }
+
+// TestScanDirectory_SkipsUnreadableSubdirectory: one unreadable entry (a
+// permission-denied subfolder, or a file removed mid-scan) used to abort the
+// whole scan, so nothing in the watch folder was ever imported while it was
+// there. Unreadable entries must be skipped, not fatal.
+func TestScanDirectory_SkipsUnreadableSubdirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	for _, singleNzbPerFolder := range []bool{false, true} {
+		t.Run(map[bool]string{false: "per-file", true: "per-folder"}[singleNzbPerFolder], func(t *testing.T) {
+			watcher, tempDir := createTestWatcher(t)
+			watcher.cfg.SingleNzbPerFolder = singleNzbPerFolder
+
+			content := bytes.Repeat([]byte("x"), 1500)
+			goodFile := createTestFile(t, tempDir, "good.bin", content, time.Now().Add(-10*time.Second))
+
+			locked := filepath.Join(tempDir, "locked")
+			if err := os.MkdirAll(locked, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			createTestFile(t, locked, "hidden.bin", content, time.Now().Add(-10*time.Second))
+			if err := os.Chmod(locked, 0o000); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+			mockQueue := &mockQueueWithDuplicateCheck{addFileCalls: make([]string, 0)}
+			watcher.queue = mockQueue
+
+			ctx := context.Background()
+			for i := 0; i < 2; i++ {
+				if err := watcher.scanDirectory(ctx); err != nil {
+					t.Fatalf("scanDirectory #%d: %v", i+1, err)
+				}
+			}
+			if len(mockQueue.addFileCalls) != 1 || mockQueue.addFileCalls[0] != goodFile {
+				t.Errorf("queued %v, want exactly [%s]", mockQueue.addFileCalls, goodFile)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Part 6 of the stacked series. **Stacked on #251** — review only the last commit.

- **Bug**: the watcher used `pwalkdir.Walk` for the size calculation and both import scans. That walker aborts on the first error and does not support `SkipDir`, so a permission-denied subfolder (or a file that vanished between listing and `Info()`) failed the entire scan. While such an entry existed *nothing* in that watch folder was imported, with `Error scanning directory` logged every cycle.
- **Fix**: a single `walkFiles` helper built on `filepath.WalkDir` skips unreadable entries with a warning (`SkipDir` for folders) and only fails when the watch root itself is unreadable. Symlink policy and the `IsDir`/`Info` boilerplate move into the helper. The walk is now sequential: every callback serialises on the single SQLite connection anyway, so the parallel walker added no throughput. `go mod tidy` drops the `opencontainers/selinux` dependency that only existed for it.

## Test plan
- [x] `TestScanDirectory_SkipsUnreadableSubdirectory` (per-file and per-folder modes) fails on the base branch with `permission denied`, passes here (skipped when running as root)
- [x] `go test -race ./internal/watcher/`, `go vet`, `golangci-lint run` clean

Stack: #247 → #248 → #249 → #250 → #251 → **this PR** → #253