### PR TITLE
fix(postie,processor): partial PAR2 sets in NZBs, orphaned transfer data on cancel

### DIFF
--- a/internal/mocks/nzb.go
+++ b/internal/mocks/nzb.go
@@ -78,3 +78,15 @@ func (mr *MockNZBGeneratorMockRecorder) Generate(outputPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockNZBGenerator)(nil).Generate), outputPath)
 }
+
+// RemoveFile mocks base method.
+func (m *MockNZBGenerator) RemoveFile(filename string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveFile", filename)
+}
+
+// RemoveFile indicates an expected call of RemoveFile.
+func (mr *MockNZBGeneratorMockRecorder) RemoveFile(filename any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFile", reflect.TypeOf((*MockNZBGenerator)(nil).RemoveFile), filename)
+}

--- a/internal/nzb/nzb.go
+++ b/internal/nzb/nzb.go
@@ -26,6 +26,8 @@ type NZBGenerator interface {
 	AddArticle(article *article.Article)
 	// AddFileHash adds a hash for a file
 	AddFileHash(filename string, hash string)
+	// RemoveFile drops every article (and hash) recorded for a file
+	RemoveFile(filename string)
 	// Generate creates an NZB file
 	Generate(outputPath string) (string, error)
 }
@@ -76,6 +78,17 @@ func (g *Generator) AddArticle(art *article.Article) {
 	// Add to index and append to articles
 	g.articleIdx[filename][art.MessageID] = len(g.articles[filename])
 	g.articles[filename] = append(g.articles[filename], art)
+}
+
+// RemoveFile drops every article and hash recorded for filename, so a file
+// whose upload was abandoned part-way is not referenced by the NZB. Unknown
+// names are a no-op.
+func (g *Generator) RemoveFile(filename string) {
+	g.mx.Lock()
+	defer g.mx.Unlock()
+	delete(g.articles, filename)
+	delete(g.articleIdx, filename)
+	delete(g.filesHash, filename)
 }
 
 // Generate creates an NZB file for all files

--- a/internal/nzb/nzb_test.go
+++ b/internal/nzb/nzb_test.go
@@ -597,3 +597,30 @@ func TestCompressWithBrotli(t *testing.T) {
 	require.NoError(t, err, "Compressed file should exist")
 	assert.Greater(t, info.Size(), int64(0), "Compressed file should not be empty")
 }
+
+func TestRemoveFile(t *testing.T) {
+	gen := NewGenerator(1000, config.NzbCompressionConfig{}, false).(*Generator)
+	gen.AddArticle(&article.Article{MessageID: "a1", OriginalName: "video.mkv", PartNumber: 1})
+	gen.AddArticle(&article.Article{MessageID: "p1", OriginalName: "video.par2", PartNumber: 1})
+	gen.AddArticle(&article.Article{MessageID: "p2", OriginalName: "video.par2", PartNumber: 2})
+	gen.AddFileHash("video.par2", "abc")
+
+	gen.RemoveFile("video.par2")
+
+	if _, ok := gen.articles["video.par2"]; ok {
+		t.Error("articles for removed file still present")
+	}
+	if _, ok := gen.articleIdx["video.par2"]; ok {
+		t.Error("article index for removed file still present")
+	}
+	if _, ok := gen.filesHash["video.par2"]; ok {
+		t.Error("hash for removed file still present")
+	}
+	if len(gen.articles["video.mkv"]) != 1 {
+		t.Errorf("unrelated file lost articles: %d", len(gen.articles["video.mkv"]))
+	}
+
+	// Removing again, or a name never added, is a no-op.
+	gen.RemoveFile("video.par2")
+	gen.RemoveFile("never-added")
+}

--- a/internal/poster/stale_conn_test.go
+++ b/internal/poster/stale_conn_test.go
@@ -70,13 +70,13 @@ func TestIsStaleConnError_RealDeadline(t *testing.T) {
 	if err != nil {
 		t.Skipf("cannot listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	conn, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil {
 		t.Skipf("cannot dial: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_ = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
 	buf := make([]byte, 1)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -399,6 +399,12 @@ func (p *Processor) processNextItem(ctx context.Context) error {
 					slog.ErrorContext(ctx, "Failed to clean up in-progress item after cancel",
 						"error", cancelErr, "id", string(msg.ID))
 				}
+				// The job will not be resumed, so its durable recovery data
+				// (planned rows, manifests) would otherwise be orphaned.
+				if discardErr := p.transferRuntime.DiscardTransfer(ctx, job.TransferID); discardErr != nil {
+					slog.WarnContext(ctx, "Failed to discard transfer after cancel",
+						"error", discardErr, "transfer", job.TransferID)
+				}
 			}
 
 			return nil

--- a/internal/transferstore/transferstore.go
+++ b/internal/transferstore/transferstore.go
@@ -397,6 +397,13 @@ func (s *Store) DeleteFilesByTransfer(ctx context.Context, transferID string) er
 	return err
 }
 
+// DeleteFailuresByTransfer removes every verification failure recorded for a
+// transfer, used when the transfer is discarded before verification.
+func (s *Store) DeleteFailuresByTransfer(ctx context.Context, transferID string) error {
+	_, err := s.db.ExecContext(ctx, "DELETE FROM verification_failures WHERE transfer_id = ?", transferID)
+	return err
+}
+
 // ListDueFiles returns files awaiting their first verification check
 // (verification_state = uploaded, next_check_at <= now), oldest first.
 func (s *Store) ListDueFiles(ctx context.Context, now time.Time, limit int) ([]TransferFile, error) {

--- a/pkg/postie/par2_partial_test.go
+++ b/pkg/postie/par2_partial_test.go
@@ -1,0 +1,95 @@
+package postie
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javi11/postie/internal/article"
+	"github.com/javi11/postie/internal/nzb"
+	"github.com/javi11/postie/internal/par2"
+)
+
+// par2FailingPoster posts every file's articles into the NZB generator like the
+// real poster does as it goes, but fails any call that includes a PAR2 file —
+// the shape of a PAR2 upload that dies after some of its articles are posted.
+type par2FailingPoster struct{ mockPoster }
+
+func (m *par2FailingPoster) Post(_ context.Context, files []string, _ string, nzbGen nzb.NZBGenerator) error {
+	for i, f := range files {
+		base := filepath.Base(f)
+		nzbGen.AddArticle(&article.Article{
+			MessageID:       base + "@test",
+			OriginalSubject: "[1/1] \"" + base + "\" yEnc (1/1)",
+			OriginalName:    base,
+			FileName:        base,
+			From:            "poster@test",
+			Groups:          []string{"alt.binaries.test"},
+			PartNumber:      1,
+			TotalParts:      1,
+			FileNumber:      i + 1,
+			Size:            100,
+		})
+	}
+	for _, f := range files {
+		if par2.IsPar2File(f) {
+			return errors.New("i/o timeout")
+		}
+	}
+	return nil
+}
+
+func (m *par2FailingPoster) PostWithRelativePaths(ctx context.Context, files []string, root string, nzbGen nzb.NZBGenerator, rel map[string]string) error {
+	return m.Post(ctx, files, root, nzbGen)
+}
+
+// TestPartialPar2UploadIsNotReferencedInNZB: in the parallel post paths a
+// failed PAR2 upload is tolerated ("upload will continue without par2"), but
+// the PAR2 articles posted before the failure were left in the NZB, producing
+// an NZB that references an incomplete PAR2 set.
+func TestPartialPar2UploadIsNotReferencedInNZB(t *testing.T) {
+	paths := map[string]postFn{
+		"postInParallel": postPaths["postInParallel"],
+		"postFolder":     postPaths["postFolder"],
+	}
+	for name, run := range paths {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			files, cleanup := makeSourceFiles(t, root, "Folder", "video.mkv")
+			defer cleanup()
+			outDir := t.TempDir()
+
+			p := newTestPostie(nil, false, false) // wait_for_par2 off → parallel branch
+			p.par2runner = &par2InDir{dir: t.TempDir()}
+			p.poster = &par2FailingPoster{}
+
+			if err := run(p, context.Background(), files, root, outDir); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+
+			var nzbs []string
+			_ = filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
+				if err == nil && strings.HasSuffix(path, ".nzb") {
+					nzbs = append(nzbs, path)
+				}
+				return nil
+			})
+			if len(nzbs) != 1 {
+				t.Fatalf("%s: found %d NZBs, want 1", name, len(nzbs))
+			}
+			data, err := os.ReadFile(nzbs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(data), ".par2") {
+				t.Errorf("%s: NZB references PAR2 segments although the PAR2 upload failed:\n%s", name, data)
+			}
+			if !strings.Contains(string(data), "video.mkv") {
+				t.Errorf("%s: NZB lost the main file", name)
+			}
+		})
+	}
+}

--- a/pkg/postie/postfolder_test.go
+++ b/pkg/postie/postfolder_test.go
@@ -123,7 +123,7 @@ func makeSourceFiles(t *testing.T, watchRoot, folderName, fileName string) ([]fi
 		Size:         7,
 		RelativePath: folderName + "/" + fileName,
 	}}
-	return files, func() { os.RemoveAll(watchRoot) }
+	return files, func() { _ = os.RemoveAll(watchRoot) }
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -373,6 +373,7 @@ func (p *Postie) postInParallel(
 			if !errors.Is(err, context.Canceled) {
 				slog.ErrorContext(ctx, fmt.Sprintf("Error during upload of par2 files: %s. Upload will continue without par2.", createdPar2Paths), "error", err)
 			}
+			dropPar2FromNZB(nzbGen, createdPar2Paths)
 
 			return nil
 		}
@@ -509,6 +510,17 @@ func (p *Postie) post(
 		return finalPath, deferredErr
 	}
 	return finalPath, nil
+}
+
+// dropPar2FromNZB removes the PAR2 files from the NZB after their upload
+// failed part-way: the articles posted before the failure were already added
+// to the generator, and an NZB pointing at an incomplete PAR2 set is worse
+// than one without PAR2 (downloaders try to repair with volumes that are not
+// there). The main files remain untouched.
+func dropPar2FromNZB(nzbGen nzb.NZBGenerator, par2Paths []string) {
+	for _, path := range par2Paths {
+		nzbGen.RemoveFile(filepath.Base(path))
+	}
 }
 
 // hasPar2Files returns true if any file in the list is a PAR2 file.
@@ -676,6 +688,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 				if !errors.Is(err, context.Canceled) {
 					slog.ErrorContext(ctx, "Error during upload of par2 files. Upload will continue without par2.", "error", err)
 				}
+				dropPar2FromNZB(nzbGen, createdPar2Paths)
 				return nil
 			}
 			return nil
@@ -789,28 +802,6 @@ func runPostUploadScript(ctx context.Context, cfg config.PostUploadScriptConfig,
 
 	slog.InfoContext(ctx, "Post upload script executed successfully", "command", command, "output", string(output))
 	return nil
-}
-
-// buildPar2RelativePaths builds a relative-path map for PAR2 files by matching each
-// par2 file's base name to its source file's base name (par2 names are sourceBase+".par2"
-// or sourceBase+".vol*+*.par2"). The relative path is derived from the source file's
-// relative path directory joined with the par2 base name.
-func buildPar2RelativePaths(sourceFiles []fileinfo.FileInfo, par2Paths []string) map[string]string {
-	result := make(map[string]string)
-	for _, par2Path := range par2Paths {
-		par2Base := filepath.Base(par2Path)
-		for _, sf := range sourceFiles {
-			if sf.RelativePath == "" {
-				continue
-			}
-			sfBase := filepath.Base(sf.Path)
-			if strings.HasPrefix(par2Base, sfBase+".") {
-				result[par2Path] = filepath.Join(filepath.Dir(sf.RelativePath), par2Base)
-				break
-			}
-		}
-	}
-	return result
 }
 
 // deriveFolderName determines the top-level subfolder name from files relative to rootDir.

--- a/pkg/postie/runtime.go
+++ b/pkg/postie/runtime.go
@@ -3,6 +3,9 @@ package postie
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	nntppool "github.com/javi11/nntppool/v4"
 	"github.com/javi11/postie/internal/config"
@@ -270,6 +273,30 @@ func (r *Runtime) TransferStore() *transferstore.Store {
 		return nil
 	}
 	return r.store
+}
+
+// DiscardTransfer forgets a transfer that will never be verified (the job was
+// cancelled): its transfer_files rows, verification failures and manifest
+// directory are removed. Without this a cancelled job leaves planned rows and
+// manifests behind forever, since they are never due for verification and the
+// cleaner only runs for verified transfers. Safe on a nil runtime, a runtime
+// without a store, and for an unknown transfer.
+func (r *Runtime) DiscardTransfer(ctx context.Context, transferID string) error {
+	if r == nil || r.store == nil || transferID == "" {
+		return nil
+	}
+	if err := r.store.DeleteFailuresByTransfer(ctx, transferID); err != nil {
+		return fmt.Errorf("discard transfer %s: delete failures: %w", transferID, err)
+	}
+	if err := r.store.DeleteFilesByTransfer(ctx, transferID); err != nil {
+		return fmt.Errorf("discard transfer %s: delete files: %w", transferID, err)
+	}
+	if r.manifestDir != "" {
+		if err := os.RemoveAll(filepath.Join(r.manifestDir, transferID)); err != nil {
+			return fmt.Errorf("discard transfer %s: remove manifests: %w", transferID, err)
+		}
+	}
+	return nil
 }
 
 // NewManifestRecorder returns a per-job manifest recorder bound to transferID,

--- a/pkg/postie/runtime_test.go
+++ b/pkg/postie/runtime_test.go
@@ -2,9 +2,12 @@ package postie
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/javi11/postie/internal/article"
 	"github.com/javi11/postie/internal/config"
 	"github.com/javi11/postie/internal/database"
 	"github.com/javi11/postie/internal/mocks"
@@ -137,5 +140,54 @@ func TestRuntime_DurableVerificationEnabled(t *testing.T) {
 	rt := &Runtime{store: store, verifyService: verification.New(store, nil, nil, verification.Config{}, "w")}
 	if !rt.DurableVerificationEnabled() {
 		t.Error("Runtime with a verify service should report durable verification enabled")
+	}
+}
+
+// TestRuntime_DiscardTransferRemovesRowsAndManifests: a cancelled durable job
+// used to leave its planned transfer_files rows, any verification failures and
+// the manifest directory behind forever (never due, never cleaned).
+func TestRuntime_DiscardTransferRemovesRowsAndManifests(t *testing.T) {
+	store := newTestTransferStore(t)
+	manifestDir := t.TempDir()
+	rt := &Runtime{store: store, manifestDir: manifestDir}
+	ctx := context.Background()
+
+	rec := rt.NewManifestRecorder("tid-cancel")
+	src := filepath.Join(t.TempDir(), "video.mkv")
+	if err := rec.RecordFile(ctx, src, []*article.Article{{MessageID: "m1", OriginalName: "video.mkv", PartNumber: 1}}); err != nil {
+		t.Fatalf("RecordFile: %v", err)
+	}
+	if err := store.AddFailure(ctx, transferstore.VerificationFailure{
+		TransferID: "tid-cancel", FileID: "f", ArticleIndex: 0, MessageID: "m1",
+		State: transferstore.FailurePending, NextAttemptAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("AddFailure: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(manifestDir, "tid-cancel")); err != nil {
+		t.Fatalf("manifest dir not created: %v", err)
+	}
+
+	if err := rt.DiscardTransfer(ctx, "tid-cancel"); err != nil {
+		t.Fatalf("DiscardTransfer: %v", err)
+	}
+
+	files, err := store.ListFilesByTransfer(ctx, "tid-cancel")
+	if err != nil || len(files) != 0 {
+		t.Errorf("transfer_files left: %d (err=%v), want 0", len(files), err)
+	}
+	if n, _ := store.CountFailures(ctx, "tid-cancel", "f", transferstore.FailurePending); n != 0 {
+		t.Errorf("verification_failures left: %d, want 0", n)
+	}
+	if _, err := os.Stat(filepath.Join(manifestDir, "tid-cancel")); !os.IsNotExist(err) {
+		t.Errorf("manifest dir still exists (err=%v), want removed", err)
+	}
+
+	// Nil-safe and idempotent.
+	var none *Runtime
+	if err := none.DiscardTransfer(ctx, "tid-cancel"); err != nil {
+		t.Errorf("nil runtime: %v", err)
+	}
+	if err := rt.DiscardTransfer(ctx, "tid-cancel"); err != nil {
+		t.Errorf("second discard: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Part 7 (last) of the stacked series, clearing the items left as "known but unfixed" in #252. **Stacked on #252** — review only the last three commits.

- **Partial PAR2 set referenced in the NZB.** In `postInParallel` and the parallel branch of `postFolder`, a failed PAR2 upload is tolerated, but the PAR2 articles posted *before* the failure were already in the NZB generator. The NZB then referenced an incomplete PAR2 set. `NZBGenerator` gains `RemoveFile`, called for the generated PAR2 files on failure; the main files are untouched. The `MockNZBGenerator` is regenerated; the unused `buildPar2RelativePaths` helper is removed.
- **Cancelled durable jobs leaked recovery data.** Their `transfer_files` rows stayed `planned` and the manifest directory stayed on disk forever (never due for verification, never reached by the cleaner). `Runtime.DiscardTransfer` removes rows, verification failures and manifests, and the processor's user-cancel branch calls it. Shutdown-cancel is unchanged so the job can still be recovered at next start.
- **Lint.** The two pre-existing `errcheck` hits in test files are fixed; `golangci-lint` is now clean for every package this series touches.

Not addressed: the `App.RemoveFromQueue` cancel glue from #251 still has no unit test because `internal/backend` has no test scaffolding; building one would be a larger change than the fix.

## Test plan
- [x] `TestRemoveFile` (generator) and `TestPartialPar2UploadIsNotReferencedInNZB` (both parallel paths) fail on the base branch, pass here
- [x] `TestRuntime_DiscardTransferRemovesRowsAndManifests` fails to compile on the base branch, passes here (also checks nil-safety and idempotence)
- [x] `go test -race` for `pkg/postie`, `internal/{nzb,poster,processor,transferstore}`; `go vet`; `golangci-lint run` 0 issues

Stack: #247 → #248 → #249 → #250 → #251 → #252 → **this PR**