### PR TITLE
test(backend): cover RemoveFromQueue cancelling a running job before removal

### DIFF
--- a/internal/backend/queue.go
+++ b/internal/backend/queue.go
@@ -249,12 +249,8 @@ func (a *App) RemoveFromQueue(id string) error {
 		return fmt.Errorf("queue not initialized")
 	}
 
-	// A running job keeps uploading after its tracking row is deleted and
-	// then re-creates a completed row; stop it first so removal is final.
-	if a.processor != nil && a.processor.GetRunningJobs()[id] {
-		if err := a.processor.CancelJob(id); err != nil {
-			slog.Warn("Failed to cancel running job before removal", "id", id, "error", err)
-		}
+	if a.processor != nil {
+		stopRunningJob(a.processor, id)
 	}
 
 	err := a.queue.RemoveFromQueue(id)
@@ -530,4 +526,20 @@ func (a *App) RecreateDatabase() error {
 
 	migrationRunner := a.database.GetMigrationRunner()
 	return migrationRunner.RecreateDatabase()
+}
+
+type jobController interface {
+	GetRunningJobs() map[string]bool
+	CancelJob(jobID string) error
+}
+
+// A running job keeps uploading after its tracking row is deleted and then
+// re-creates a completed row, so removal is only final once the job is stopped.
+func stopRunningJob(jobs jobController, id string) {
+	if !jobs.GetRunningJobs()[id] {
+		return
+	}
+	if err := jobs.CancelJob(id); err != nil {
+		slog.Warn("Failed to cancel running job before removal", "id", id, "error", err)
+	}
 }

--- a/internal/backend/queue_test.go
+++ b/internal/backend/queue_test.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/postie/internal/config"
+	"github.com/javi11/postie/internal/database"
+	"github.com/javi11/postie/internal/queue"
+)
+
+type fakeJobController struct {
+	running   map[string]bool
+	cancelled []string
+}
+
+func (f *fakeJobController) GetRunningJobs() map[string]bool { return f.running }
+
+func (f *fakeJobController) CancelJob(id string) error {
+	f.cancelled = append(f.cancelled, id)
+	return nil
+}
+
+func TestStopRunningJob_CancelsOnlyWhenRunning(t *testing.T) {
+	jc := &fakeJobController{running: map[string]bool{"running-job": true}}
+
+	stopRunningJob(jc, "running-job")
+	stopRunningJob(jc, "idle-job")
+
+	if len(jc.cancelled) != 1 || jc.cancelled[0] != "running-job" {
+		t.Fatalf("expected only running-job to be cancelled, got %v", jc.cancelled)
+	}
+}
+
+func newTestQueue(t *testing.T) *queue.Queue {
+	t.Helper()
+	ctx := context.Background()
+	db, err := database.New(ctx, config.DatabaseConfig{
+		DatabaseType: "sqlite",
+		DatabasePath: filepath.Join(t.TempDir(), "test.db"),
+	})
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.GetMigrationRunner().MigrateUp(); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	q, err := queue.New(ctx, db)
+	if err != nil {
+		t.Fatalf("queue.New: %v", err)
+	}
+	t.Cleanup(func() { _ = q.Close() })
+	return q
+}
+
+func TestRemoveFromQueue_RemovesPendingItemAndEmitsEvent(t *testing.T) {
+	q := newTestQueue(t)
+	ctx := context.Background()
+	if err := q.AddFile(ctx, filepath.Join(t.TempDir(), "a.bin"), 10); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	items, err := q.GetQueueItems(queue.PaginationParams{Page: 1, Limit: 10})
+	if err != nil || len(items.Items) != 1 {
+		t.Fatalf("GetQueueItems: items=%d err=%v", len(items.Items), err)
+	}
+
+	var events []string
+	app := &App{
+		queue:           q,
+		isWebMode:       true,
+		webEventEmitter: func(eventType string, _ any) { events = append(events, eventType) },
+	}
+
+	if err := app.RemoveFromQueue(items.Items[0].ID); err != nil {
+		t.Fatalf("RemoveFromQueue: %v", err)
+	}
+
+	after, err := q.GetQueueItems(queue.PaginationParams{Page: 1, Limit: 10})
+	if err != nil {
+		t.Fatalf("GetQueueItems: %v", err)
+	}
+	if len(after.Items) != 0 {
+		t.Fatalf("expected queue to be empty, got %d items", len(after.Items))
+	}
+	if len(events) != 1 || events[0] != "queue-updated" {
+		t.Fatalf("expected one queue-updated event, got %v", events)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the test gap left in #251: the cancel-before-remove glue in `App.RemoveFromQueue` had no unit test because `internal/backend` had no test scaffolding.

- Extracts the cancel decision into `stopRunningJob(jobController, id)` behind a two-method interface so the glue can be tested without a live `processor.Processor`.
- Adds the first tests for `internal/backend`: a real SQLite queue plus an `App` in web mode, asserting the pending item is removed and exactly one `queue-updated` event is emitted; and a fake job controller asserting `CancelJob` is invoked only for a job that is actually running.

No behaviour change.

## Test plan

- [x] `go test -race ./internal/backend/` passes
- [x] `golangci-lint run ./internal/backend/` clean