### PR TITLE
fix(progress): compute upload speed and ETA from active transfer time only

### DIFF
--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -117,6 +117,7 @@ func (pm *jobProgress) AddProgress(
 		pType:     pType,
 		total:     total,
 		startTime: time.Now(),
+		clock:     time.Now,
 		progress: progressbar.NewOptions64(
 			total,
 			progressbar.OptionSetDescription(name),
@@ -224,13 +225,45 @@ type progress struct {
 	progress     *progressbar.ProgressBar
 	paused       bool
 	waitDeadline time.Time
+	clock        func() time.Time
+	bytes        int64
+	firstByteAt  time.Time
+	pausedAt     time.Time
+	pausedTotal  time.Duration
 	mu           sync.RWMutex
+}
+
+// activeSeconds is the time spent actually transferring: from the first byte
+// onwards, minus any paused intervals. Wall-clock time since the bar was
+// created includes queue waits and pauses, which made the displayed speed
+// meaningless for jobs that sat behind other uploads.
+func (p *progress) activeSeconds(now time.Time) float64 {
+	if p.firstByteAt.IsZero() {
+		return 0
+	}
+	active := now.Sub(p.firstByteAt) - p.pausedTotal
+	if !p.pausedAt.IsZero() {
+		active -= now.Sub(p.pausedAt)
+	}
+	return active.Seconds()
 }
 
 func (p *progress) UpdateProgress(processed int64) {
 	if p.progress.IsFinished() {
 		return
 	}
+
+	p.mu.Lock()
+	if p.firstByteAt.IsZero() {
+		now := p.clock()
+		p.firstByteAt = now
+		p.pausedTotal = 0
+		if p.paused {
+			p.pausedAt = now
+		}
+	}
+	p.bytes += processed
+	p.mu.Unlock()
 
 	_ = p.progress.Add64(processed)
 }
@@ -257,7 +290,19 @@ func (p *progress) GetState() ProgressState {
 	p.mu.RLock()
 	paused := p.paused
 	waitDeadline := p.waitDeadline
+	now := p.clock()
+	bytes := p.bytes
+	activeSecs := p.activeSeconds(now)
 	p.mu.RUnlock()
+
+	kbsPerSecond := 0.0
+	secondsLeft := 0.0
+	if bytes > 0 && activeSecs > 0 {
+		kbsPerSecond = float64(bytes) / 1024.0 / activeSecs
+		if remaining := p.total - bytes; remaining > 0 {
+			secondsLeft = float64(remaining) / (kbsPerSecond * 1024.0)
+		}
+	}
 
 	secsRemaining := 0.0
 	isWaiting := false
@@ -283,16 +328,6 @@ func (p *progress) GetState() ProgressState {
 	secondsSince := s.SecondsSince
 	if math.IsNaN(secondsSince) || math.IsInf(secondsSince, 0) {
 		secondsSince = 0.0
-	}
-
-	secondsLeft := s.SecondsLeft
-	if math.IsNaN(secondsLeft) || math.IsInf(secondsLeft, 0) {
-		secondsLeft = 0.0
-	}
-
-	kbsPerSecond := s.KBsPerSecond
-	if math.IsNaN(kbsPerSecond) || math.IsInf(kbsPerSecond, 0) {
-		kbsPerSecond = 0.0
 	}
 
 	return ProgressState{
@@ -347,7 +382,17 @@ func (p *progress) GetLeftTime() time.Duration {
 func (p *progress) SetPaused(paused bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if paused == p.paused {
+		return
+	}
 	p.paused = paused
+	now := p.clock()
+	if paused {
+		p.pausedAt = now
+		return
+	}
+	p.pausedTotal += now.Sub(p.pausedAt)
+	p.pausedAt = time.Time{}
 }
 
 func (p *progress) IsPaused() bool {

--- a/internal/progress/speed_test.go
+++ b/internal/progress/speed_test.go
@@ -1,0 +1,92 @@
+package progress
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func newClockedProgress(t *testing.T, total int64, now *time.Time) *progress {
+	t.Helper()
+	job := NewProgressJob("job")
+	t.Cleanup(job.Close)
+	p, ok := job.AddProgress(uuid.New(), "file.bin", ProgressTypeUploading, total).(*progress)
+	if !ok {
+		t.Fatal("AddProgress did not return *progress")
+	}
+	p.clock = func() time.Time { return *now }
+	return p
+}
+
+func assertClose(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 0.01 {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}
+
+func TestSpeedExcludesTimeWaitingForFirstByte(t *testing.T) {
+	now := time.Unix(1000, 0)
+	p := newClockedProgress(t, 4096, &now)
+
+	now = now.Add(30 * time.Second)
+	p.UpdateProgress(1024)
+	now = now.Add(1 * time.Second)
+	p.UpdateProgress(1024)
+
+	assertClose(t, "KBsPerSecond", p.GetState().KBsPerSecond, 2.0)
+}
+
+func TestSpeedExcludesPausedTime(t *testing.T) {
+	now := time.Unix(1000, 0)
+	p := newClockedProgress(t, 4096, &now)
+
+	p.UpdateProgress(1024)
+	now = now.Add(1 * time.Second)
+	p.SetPaused(true)
+	now = now.Add(10 * time.Second)
+	p.SetPaused(false)
+	now = now.Add(1 * time.Second)
+	p.UpdateProgress(1024)
+
+	assertClose(t, "KBsPerSecond", p.GetState().KBsPerSecond, 1.0)
+}
+
+func TestSecondsLeftUsesActiveSpeed(t *testing.T) {
+	now := time.Unix(1000, 0)
+	p := newClockedProgress(t, 4096, &now)
+
+	now = now.Add(30 * time.Second)
+	p.UpdateProgress(1024)
+	now = now.Add(1 * time.Second)
+	p.UpdateProgress(1024)
+
+	assertClose(t, "SecondsLeft", p.GetState().SecondsLeft, 1.0)
+}
+
+func TestSpeedIsZeroBeforeFirstByte(t *testing.T) {
+	now := time.Unix(1000, 0)
+	p := newClockedProgress(t, 4096, &now)
+	now = now.Add(5 * time.Second)
+
+	s := p.GetState()
+	assertClose(t, "KBsPerSecond", s.KBsPerSecond, 0)
+	assertClose(t, "SecondsLeft", s.SecondsLeft, 0)
+}
+
+func TestPauseBeforeFirstByteDoesNotSkewSpeed(t *testing.T) {
+	now := time.Unix(1000, 0)
+	p := newClockedProgress(t, 4096, &now)
+
+	p.SetPaused(true)
+	now = now.Add(10 * time.Second)
+	p.SetPaused(false)
+	now = now.Add(5 * time.Second)
+	p.UpdateProgress(1024)
+	now = now.Add(1 * time.Second)
+	p.UpdateProgress(1024)
+
+	assertClose(t, "KBsPerSecond", p.GetState().KBsPerSecond, 2.0)
+}


### PR DESCRIPTION
## Summary

Addresses the "speed statistics are not accurate at all" report in #168.

The per-file speed shown on the dashboard came straight from `schollz/progressbar`, which divides bytes by wall-clock time since the bar was **created**. Two things make that number meaningless in Postie:

- A file's bar is created when the post is queued in `addPost`, but with the shared worker pool the bytes only start flowing once a worker picks it up. Under a large batch a file can sit queued for minutes, so its speed reads as a fraction of the real rate for the whole upload.
- Pausing only set a flag; the paused seconds kept counting against the speed, and the ETA (`SecondsLeft`) was derived from the same skewed rate.

`progress` now tracks the bytes itself and reports speed as bytes over **active** seconds: from the first byte onward, minus paused intervals. `SecondsLeft` is derived from that rate. Other fields (`CurrentPercent`, `SecondsSince`, `CurrentBytes`) are unchanged.

## Test plan

- [x] New `internal/progress/speed_test.go` with an injected clock: queue wait excluded, paused time excluded, pause before first byte handled, ETA uses the active rate, zero before first byte. All fail on `main`.
- [x] `go test -race` on `internal/progress`, `internal/poster`, `pkg/postie`, `internal/processor`
- [x] `golangci-lint run ./internal/progress/` clean