### PR TITLE
ci(windows): smoke test the built CLI exe before publishing artifacts

### DIFF
--- a/.github/actions/smoke-test-cli/action.yml
+++ b/.github/actions/smoke-test-cli/action.yml
@@ -1,0 +1,42 @@
+name: Smoke test CLI startup
+description: Runs the freshly built CLI binary to catch launch-time regressions (missing runtime DLLs, init panics, stray startup errors) before the artifact is published.
+inputs:
+  binary:
+    description: Path to the built CLI binary
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Run CLI startup checks
+      shell: bash
+      run: |
+        set -euo pipefail
+        bin="${{ inputs.binary }}"
+
+        echo "--- $bin --help"
+        "$bin" --help > help.out 2>&1
+        cat help.out
+        grep -q "Path to configuration file" help.out
+
+        echo "--- $bin -c missing-config.yaml (expect exit 1 and only the config error)"
+        set +e
+        "$bin" -c missing-config.yaml > run.out 2>&1
+        code=$?
+        set -e
+        cat run.out
+        if [ "$code" -ne 1 ]; then
+          echo "::error::expected exit code 1 for a missing config, got $code"
+          exit 1
+        fi
+        grep -q "error reading config file" run.out || {
+          echo "::error::CLI did not report the missing config file"
+          exit 1
+        }
+        if grep -iE "error|panic|fatal" run.out \
+            | grep -v "Error loading configuration" \
+            | grep -v "^Error: error reading config file"; then
+          echo "::error::unexpected output during CLI startup (see lines above)"
+          exit 1
+        fi
+        rm -f help.out run.out
+        echo "OK: CLI starts, parses flags, and reports only the expected config error."

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -196,6 +196,11 @@ jobs:
         with:
           exe-glob: postie-cli-windows-amd64.exe
 
+      - name: Smoke test CLI startup
+        uses: ./.github/actions/smoke-test-cli
+        with:
+          binary: ./postie-cli-windows-amd64.exe
+
       - name: Upload Windows CLI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,14 @@ jobs:
         with:
           exe-glob: postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}.exe
 
+      # Issue #154: the rc7 CLI printed errors at launch on Windows and nothing
+      # in CI exercised the exe. Run it once before packaging.
+      - name: Smoke test CLI startup
+        if: matrix.goos == 'windows'
+        uses: ./.github/actions/smoke-test-cli
+        with:
+          binary: ./postie-cli-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+
       # Create archive
       - name: Create archive
         run: |


### PR DESCRIPTION
## Summary

Issue #154 reports errors printed by the Windows CLI at launch since v0.0.29-rc7. The screenshots carry no text and nobody has a Windows box to reproduce on, but the underlying gap is clear: CI builds the Windows exe, checks its DLL imports, and never runs it.

This adds a composite action `smoke-test-cli` that executes the freshly built binary on the Windows runner and fails the job if:

- `--help` does not run or does not print the flag table (a missing runtime DLL or an init panic fails here),
- `-c missing-config.yaml` exits with anything other than `1` or does not report the missing config,
- anything matching `error|panic|fatal` appears at startup other than the expected config error.

Wired into `dev-build.yml` (Windows CLI job) and `release.yml` (Windows entry of the CLI matrix), right after the existing DLL-import check and before packaging.

Verified locally: the script passes against a native build and fails when a wrapper injects one extra `ERROR` line at startup.

Not included: running the Go unit tests on a Windows runner. Several tests rely on Unix behaviour (chmod-based permission tests, sockets, `/tmp` paths) and would need porting first.

## Test plan

- [x] YAML validated
- [x] Script dry-run: positive and negative cases
- [ ] First `Dev Build` run on `main` after merge shows the new step green on `build-cli-windows`