### PR TITLE
ci: run Go unit tests on windows-latest

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -22,6 +22,53 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/test
 
+  test-windows:
+    runs-on: windows-latest
+    needs: []
+    timeout-minutes: 30
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: ''
+          update: false
+          path-type: inherit
+
+      # Pin the MinGW GCC toolchain (see build-cli-windows for rationale).
+      - name: Pin MinGW GCC toolchain
+        shell: msys2 {0}
+        run: |
+          GCC_VER=15.2.0-14
+          pacman -U --noconfirm \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-${GCC_VER}-any.pkg.tar.zst \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-${GCC_VER}-any.pkg.tar.zst
+          gcc --version
+
+      - name: Runner CPU info
+        shell: pwsh
+        run: Get-CimInstance Win32_Processor | Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | Format-List
+
+      # The root package embeds frontend/build, which is not built here, so the
+      # sweep is limited to the library packages.
+      - name: Go tests
+        shell: msys2 {0}
+        env:
+          CGO_ENABLED: 1
+          CC: gcc
+        run: |
+          go version
+          go test -count=1 ./internal/... ./pkg/...
+
   build-frontend:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,3 +26,50 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/test
+
+  test-windows:
+    runs-on: windows-latest
+    needs: []
+    timeout-minutes: 30
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.26
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: ''
+          update: false
+          path-type: inherit
+
+      # Pin the MinGW GCC toolchain (see build-cli-windows for rationale).
+      - name: Pin MinGW GCC toolchain
+        shell: msys2 {0}
+        run: |
+          GCC_VER=15.2.0-14
+          pacman -U --noconfirm \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-${GCC_VER}-any.pkg.tar.zst \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-${GCC_VER}-any.pkg.tar.zst
+          gcc --version
+
+      - name: Runner CPU info
+        shell: pwsh
+        run: Get-CimInstance Win32_Processor | Select-Object Name, NumberOfCores, NumberOfLogicalProcessors | Format-List
+
+      # The root package embeds frontend/build, which is not built here, so the
+      # sweep is limited to the library packages.
+      - name: Go tests
+        shell: msys2 {0}
+        env:
+          CGO_ENABLED: 1
+          CC: gcc
+        run: |
+          go version
+          go test -count=1 ./internal/... ./pkg/...

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sync"
 	"testing"
@@ -1136,6 +1137,9 @@ func TestScan_JobsCarryWatcherInputFolder(t *testing.T) {
 // whole scan, so nothing in the watch folder was ever imported while it was
 // there. Unreadable entries must be skipped, not fatal.
 func TestScanDirectory_SkipsUnreadableSubdirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits are not enforced on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root ignores directory permissions")
 	}

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -823,7 +823,7 @@ func deriveFolderName(rootDir string, files []fileinfo.FileInfo) string {
 	}
 	// Fallback: use the base name of rootDir itself
 	name := filepath.Base(rootDir)
-	if name == "." || name == "/" || name == "" {
+	if name == "." || name == string(filepath.Separator) || name == "" {
 		return "upload"
 	}
 	return name


### PR DESCRIPTION
## Summary

Runs the Go unit test suite on `windows-latest` in CI, and makes it green.

- New job `test-windows` in `.github/workflows/pull-request.yml` and `.github/workflows/dev-build.yml` (`needs: []`, so it does not gate the Linux `test` job; `timeout-minutes: 30`).
- Reuses the exact cgo toolchain recipe from `build-cli-windows`: `msys2/setup-msys2` (MINGW64, `path-type: inherit`), the `Pin MinGW GCC toolchain` step (GCC 15.2.0-14), `shell: msys2 {0}`, `CGO_ENABLED=1`, `CC=gcc`, so par2go's prebuilt static lib links.
- Adds a `Runner CPU info` step (`Get-CimInstance Win32_Processor`) mirroring the Linux one, so a native PAR2 crash can be tied to a CPU family.
- Runs `go test -count=1 ./internal/... ./pkg/...` (not `./...`: the root package embeds `frontend/build`, which is not built in this job).

## Production code changed

**`pkg/postie/postie.go` — `deriveFolderName`** (real Windows bug, surfaced by `TestDeriveFolderName/rootDir_is_root_slash`):
the fallback compared `filepath.Base(rootDir)` against `"/"`, but on Windows `filepath.Base` of a root (`/`, `C:\`) returns `\`. Watching a drive root would therefore produce an NZB folder literally named `\` instead of the `upload` fallback. Now compares against `string(filepath.Separator)` (identical behaviour on Unix).

## Tests touched

| Test | Change | Why |
|---|---|---|
| `internal/watcher` `TestScanDirectory_SkipsUnreadableSubdirectory` | `t.Skip` on `runtime.GOOS == "windows"` (in addition to the existing root/euid check) | Uses `os.Chmod(dir, 0o000)` to make a directory unreadable; POSIX permission bits are not enforced on Windows, so the scenario cannot be reproduced there. |

No test was deleted or weakened. `TestDeriveFolderName` itself is unchanged; its expectation was correct and exposed the bug above.

## Remaining skips on Windows

1 test: `TestScanDirectory_SkipsUnreadableSubdirectory` (reason above).

## Verification

- Windows job green: https://github.com/kipsilabs/postie/actions/runs/33974967512/job/101329946058
- First Windows run (pre-fix), showing the single failure: https://github.com/kipsilabs/postie/actions/runs/33974747223
- Locally (macOS): `go test -race -count=1 ./internal/... ./pkg/...` green; `gofmt -l` clean and `go vet` clean on touched packages.
