### PR TITLE
fix: recover from provider outages and repair the from-source build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,38 +92,38 @@ dev:
 	go tool wails dev
 
 .PHONY: build
-build: build-cli build-client
+build: build-cli build-web
 	@echo "Build completed!"
 	@echo "CLI binary: ./postie-cli"
-	@echo "Client binary: ./postie-client"
+	@echo "Web server binary: ./postie-web"
 	@echo "GUI binary: ./build/bin/postie(.app on macOS)"
 
 .PHONY: build-debug
-build-debug: build-cli-debug build-client-debug build-gui-debug
+build-debug: build-cli-debug build-web-debug build-gui-debug
 	@echo "Debug build completed!"
 	@echo "CLI binary: ./postie-cli-debug"
-	@echo "Client binary: ./postie-client-debug"
+	@echo "Web server binary: ./postie-web-debug"
 	@echo "GUI binary: ./build/bin/postie(.app on macOS)"
 
 .PHONY: build-cli
 build-cli:
 	@echo "Building CLI..."
-	$(GO) build -o postie-cli .
+	$(GO) build -o postie-cli ./cmd/postie
 
 .PHONY: build-cli-debug
 build-cli-debug:
 	@echo "Building CLI (debug)..."
-	$(GO) build -tags debug -o postie-cli-debug .
+	$(GO) build -tags debug -o postie-cli-debug ./cmd/postie
 
-.PHONY: build-client
-build-client:
-	@echo "Building Client..."
-	$(GO) build -o postie-client ./cmd/main
+.PHONY: build-web
+build-web:
+	@echo "Building Web server..."
+	$(GO) build -o postie-web ./cmd/web
 
-.PHONY: build-client-debug
-build-client-debug:
-	@echo "Building Client (debug)..."
-	$(GO) build -tags debug -o postie-client-debug ./cmd/main
+.PHONY: build-web-debug
+build-web-debug:
+	@echo "Building Web server (debug)..."
+	$(GO) build -tags debug -o postie-web-debug ./cmd/web
 
 .PHONY: build-gui
 build-gui:
@@ -154,16 +154,16 @@ run-cli: build-cli
 	@echo "Running CLI..."
 	./postie-cli $(ARGS)
 
-.PHONY: run-client
-run-client: build-client
-	@echo "Running Client..."
-	./postie-client $(ARGS)
+.PHONY: run-web
+run-web: build-web
+	@echo "Running web server..."
+	./postie-web $(ARGS)
 
 .PHONY: clean-build
 clean-build:
 	@echo "Cleaning build artifacts..."
 	rm -rf build/
-	rm -f postie-cli postie-cli-debug postie-client postie-client-debug
+	rm -f postie-cli postie-cli-debug postie-web postie-web-debug
 	rm -rf frontend/dist/
 	rm -rf frontend/node_modules/
 	@echo "Clean completed!"
@@ -178,14 +178,14 @@ help:
 	@echo "Building:"
 	@echo "  build            - Build production version (CLI + Client + GUI)"
 	@echo "  build-debug      - Build debug version (CLI + Client + GUI)"
-	@echo "  build-cli        - Build CLI only (uses root main)"
-	@echo "  build-client     - Build Client only (uses cmd/main)"
+	@echo "  build-cli        - Build CLI only (cmd/postie)"
+	@echo "  build-web        - Build web server only (cmd/web)"
 	@echo "  build-gui        - Build GUI only"
 	@echo ""
 	@echo "Running:"
 	@echo "  run              - Build and run the GUI"
 	@echo "  run-cli ARGS=... - Build and run CLI"
-	@echo "  run-client ARGS=... - Build and run Client"
+	@echo "  run-web ARGS=...    - Build and run the web server"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  clean-build      - Clean build artifacts"
@@ -195,7 +195,7 @@ help:
 	@echo "  make dev                    # Start GUI development mode"
 	@echo "  make build                  # Build all components"
 	@echo "  make run-cli ARGS='--help'  # Show CLI help"
-	@echo "  make run-client ARGS='...'  # Run client with args"
+	@echo "  make run-web ARGS='...'     # Run web server with args"
 
 .PHONY: clean
 clean: clean-build

--- a/README.md
+++ b/README.md
@@ -60,19 +60,53 @@ For detailed documentation, installation instructions, configuration options, an
 
 ## For Developers
 
+### Prerequisites
+
+- **Go** 1.26+
+- **[Bun](https://bun.sh)** — used for the frontend (do not use npm)
+- A **C toolchain**, because the native PAR2 encoder uses cgo. On Windows use
+  [MSYS2](https://www.msys2.org/) with the MinGW-w64 GCC toolchain and build
+  from the MSYS2 shell; on macOS the Xcode command line tools are enough.
+
+Wails does not need to be installed separately — it is declared as a Go tool
+dependency and runs via `go tool wails`.
+
 ### Building from Source
+
+The Go binaries embed the compiled frontend, so **the frontend must be built
+first**. Skipping this step fails with
+`pattern all:frontend/build: no matching files found`.
 
 ```bash
 git clone https://github.com/kipsilabs/postie.git
 cd postie
-go build
+
+make build-frontend   # cd frontend && bun i && bun run build
+make build            # CLI + web server
+```
+
+Individual targets:
+
+| Command | Builds | Output |
+|---------|--------|--------|
+| `make build-cli` | CLI (`./cmd/postie`) | `./postie-cli` |
+| `make build-web` | Web server (`./cmd/web`) | `./postie-web` |
+| `make build-gui` | Desktop app via Wails | `./build/bin/postie` (`.app` on macOS) |
+
+Run `make help` for the full target list, and `make check` before opening a pull
+request (it runs `go generate`, `go mod tidy`, golangci-lint and the race tests).
+
+### Development Mode
+
+```bash
+make dev          # desktop app with hot reload
 ```
 
 ### Installing with Go
 
-```bash
-go install github.com/kipsilabs/postie@latest
-```
+`go install` cannot build this repository, because the embedded frontend assets
+are not present in a fresh module cache. Use the release binaries, or build from
+source as above.
 
 ## License
 

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1070,7 +1070,11 @@ func (p *Processor) checkAndHandleProviderAvailability() {
 	// Do not touch the manual pause state — if the user manually paused,
 	// that remains in effect.
 	if activeProviders > 0 && wasAutoPaused {
-		slog.Info("Providers available - unblocking new jobs",
+		// This also fires as a probe: with no jobs running, no new errors can
+		// accrue, so a still-dead provider looks reachable until the next job
+		// actually tries it. That retry is the point — never unblocking is the
+		// failure mode this replaced.
+		slog.Info("No new provider errors since last check - allowing new jobs",
 			"activeProviders", activeProviders)
 		p.setAutoBlock(false)
 

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -58,6 +58,9 @@ type Processor struct {
 	isAutoBlockingNewJobs bool // blocks new jobs without pausing running ones
 	autoPausedMux         sync.RWMutex
 	providerCheckTicker   *time.Ticker
+	// providerErrorBaseline holds each provider's cumulative error count as of
+	// the previous availability check. Only touched by the monitor goroutine.
+	providerErrorBaseline map[string]int64
 	providerCheckCtx      context.Context
 	providerCheckCancel   context.CancelFunc
 	// Callback to check if processor can start new items
@@ -1031,16 +1034,12 @@ func (p *Processor) checkAndHandleProviderAvailability() {
 		return
 	}
 
-	// Count connected/active providers
-	activeProviders := 0
+	// Count reachable providers. Error counts are cumulative, so they only carry
+	// health information as a delta against the previous check — see
+	// evaluateProviderAvailability.
 	totalProviders := len(metrics.Providers)
-
-	for _, provider := range metrics.Providers {
-		// Consider a provider active if it has active connections or no errors
-		if provider.ActiveConnections > 0 || provider.Errors == 0 {
-			activeProviders++
-		}
-	}
+	activeProviders, nextBaseline := evaluateProviderAvailability(metrics, p.providerErrorBaseline)
+	p.providerErrorBaseline = nextBaseline
 
 	p.autoPausedMux.Lock()
 	wasAutoPaused := p.isAutoPaused

--- a/internal/processor/provider_availability.go
+++ b/internal/processor/provider_availability.go
@@ -11,6 +11,13 @@ import "github.com/javi11/nntppool/v4"
 // recorded no new errors since the last check. Providers seen for the first
 // time only seed the baseline: errors from before monitoring started say
 // nothing about current reachability.
+//
+// The counter can also go down: editing a server in the settings makes
+// Manager.UpdateConfig remove and re-add the provider under the same key, which
+// installs a fresh stats struct. A decrease is read as "no new errors", giving
+// the reconfigured provider a clean slate. The cost is that errors accrued
+// between such a reset and the next check can be masked for a single cycle,
+// which resolves itself because the baseline is replaced on every call.
 func evaluateProviderAvailability(stats nntppool.ClientStats, baseline map[string]int64) (int, map[string]int64) {
 	next := make(map[string]int64, len(stats.Providers))
 	healthy := 0

--- a/internal/processor/provider_availability.go
+++ b/internal/processor/provider_availability.go
@@ -1,0 +1,28 @@
+package processor
+
+import "github.com/javi11/nntppool/v4"
+
+// evaluateProviderAvailability counts how many providers look reachable and
+// returns the error baseline to compare against on the next check.
+//
+// ProviderStats.Errors is cumulative since client start, so it can only be read
+// as a health signal by comparing it against the previous observation. A
+// provider is considered reachable when it either holds live connections or has
+// recorded no new errors since the last check. Providers seen for the first
+// time only seed the baseline: errors from before monitoring started say
+// nothing about current reachability.
+func evaluateProviderAvailability(stats nntppool.ClientStats, baseline map[string]int64) (int, map[string]int64) {
+	next := make(map[string]int64, len(stats.Providers))
+	healthy := 0
+
+	for _, provider := range stats.Providers {
+		previous, seen := baseline[provider.Name]
+		next[provider.Name] = provider.Errors
+
+		if provider.ActiveConnections > 0 || !seen || provider.Errors <= previous {
+			healthy++
+		}
+	}
+
+	return healthy, next
+}

--- a/internal/processor/provider_availability_test.go
+++ b/internal/processor/provider_availability_test.go
@@ -1,0 +1,86 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/javi11/nntppool/v4"
+)
+
+func TestEvaluateProviderAvailability(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseline    map[string]int64
+		providers   []nntppool.ProviderStats
+		wantHealthy int
+	}{
+		{
+			// Regression for #172: ProviderStats.Errors is cumulative since client
+			// start, so a single historical error used to mark an idle provider
+			// unavailable forever. Blocking new jobs then guaranteed
+			// ActiveConnections stayed 0, so the block could never lift.
+			name:        "idle provider with only historical errors stays healthy",
+			baseline:    map[string]int64{"news.example.com": 5},
+			providers:   []nntppool.ProviderStats{{Name: "news.example.com", Errors: 5, ActiveConnections: 0}},
+			wantHealthy: 1,
+		},
+		{
+			name:        "idle provider accruing new errors is unhealthy",
+			baseline:    map[string]int64{"news.example.com": 5},
+			providers:   []nntppool.ProviderStats{{Name: "news.example.com", Errors: 9, ActiveConnections: 0}},
+			wantHealthy: 0,
+		},
+		{
+			name:        "provider with live connections is healthy despite new errors",
+			baseline:    map[string]int64{"news.example.com": 5},
+			providers:   []nntppool.ProviderStats{{Name: "news.example.com", Errors: 9, ActiveConnections: 3}},
+			wantHealthy: 1,
+		},
+		{
+			// Errors accumulated before monitoring started say nothing about
+			// current reachability; the first observation only seeds the baseline.
+			name:        "first observation seeds the baseline without blocking",
+			baseline:    map[string]int64{},
+			providers:   []nntppool.ProviderStats{{Name: "news.example.com", Errors: 100, ActiveConnections: 0}},
+			wantHealthy: 1,
+		},
+		{
+			name:     "healthy providers are counted independently of failing ones",
+			baseline: map[string]int64{"good.example.com": 0, "bad.example.com": 2},
+			providers: []nntppool.ProviderStats{
+				{Name: "good.example.com", Errors: 0, ActiveConnections: 0},
+				{Name: "bad.example.com", Errors: 7, ActiveConnections: 0},
+			},
+			wantHealthy: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := nntppool.ClientStats{Providers: tt.providers}
+
+			healthy, next := evaluateProviderAvailability(stats, tt.baseline)
+
+			if healthy != tt.wantHealthy {
+				t.Errorf("healthy providers = %d; want %d", healthy, tt.wantHealthy)
+			}
+			for _, p := range tt.providers {
+				if got := next[p.Name]; got != p.Errors {
+					t.Errorf("baseline[%q] = %d; want %d (current cumulative count)", p.Name, got, p.Errors)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateProviderAvailabilityForgetsRemovedProviders(t *testing.T) {
+	baseline := map[string]int64{"removed.example.com": 4}
+	stats := nntppool.ClientStats{
+		Providers: []nntppool.ProviderStats{{Name: "kept.example.com", Errors: 1}},
+	}
+
+	_, next := evaluateProviderAvailability(stats, baseline)
+
+	if _, ok := next["removed.example.com"]; ok {
+		t.Error("baseline retained a provider that is no longer configured")
+	}
+}

--- a/internal/processor/provider_availability_test.go
+++ b/internal/processor/provider_availability_test.go
@@ -72,6 +72,34 @@ func TestEvaluateProviderAvailability(t *testing.T) {
 	}
 }
 
+// The monitor's baseline field starts as a nil map, so the first real call
+// always passes nil rather than an empty map.
+func TestEvaluateProviderAvailabilityWithNilBaseline(t *testing.T) {
+	stats := nntppool.ClientStats{
+		Providers: []nntppool.ProviderStats{{Name: "news.example.com", Errors: 42}},
+	}
+
+	healthy, next := evaluateProviderAvailability(stats, nil)
+
+	if healthy != 1 {
+		t.Errorf("healthy providers = %d; want 1 (first observation only seeds the baseline)", healthy)
+	}
+	if got := next["news.example.com"]; got != 42 {
+		t.Errorf("baseline = %d; want 42", got)
+	}
+}
+
+func TestEvaluateProviderAvailabilityWithNoProviders(t *testing.T) {
+	healthy, next := evaluateProviderAvailability(nntppool.ClientStats{}, nil)
+
+	if healthy != 0 {
+		t.Errorf("healthy providers = %d; want 0", healthy)
+	}
+	if len(next) != 0 {
+		t.Errorf("baseline has %d entries; want 0", len(next))
+	}
+}
+
 func TestEvaluateProviderAvailabilityForgetsRemovedProviders(t *testing.T) {
 	baseline := map[string]int64{"removed.example.com": 4}
 	stats := nntppool.ClientStats{


### PR DESCRIPTION
Two independent fixes that came out of triaging the open issue list. Happy to split them if you'd rather review separately.

## 1. Uploads never resume after a provider blip — closes #172

`checkAndHandleProviderAvailability` counted a provider healthy with:

```go
provider.ActiveConnections > 0 || provider.Errors == 0
```

`nntppool.ProviderStats.Errors` is **cumulative since client start**, not a current-state signal. One transient error therefore disqualified a provider for the rest of the process lifetime unless it happened to be holding live connections.

That made the auto-block self-sustaining. With new jobs blocked, `processQueueItems` early-returns on every pickup, so no connection is ever opened, `ActiveConnections` stays 0, and the unblock branch can never fire. The queue stops for good — matching the report: *"requiring the file to be canceled and manually unpaused"*.

The counter is now read as a delta against the previous check, extracted into a pure `evaluateProviderAvailability` so the decision is testable without a live pool. A provider counts as reachable when it holds connections or has recorded no new errors since the last check; a provider seen for the first time only seeds the baseline, since errors from before monitoring started say nothing about current reachability.

Two consequences worth knowing at review time:

- **The counter can go down.** `Manager.UpdateConfig` removes and re-adds a provider under the same key on any pool-affecting settings edit, installing fresh stats. A decrease reads as "no new errors", so a reconfigured provider gets a clean slate. Errors accrued between such a reset and the next check can be masked for one cycle; the baseline is replaced on every call, so it resolves itself.
- **A dead provider now flaps** block/unblock every 30s while there is queued work, because unblocking is what lets a job probe the provider. That is the intended trade — never unblocking is the bug being removed. The log line no longer claims "Providers available", since the check hasn't observed that when it is only probing.

## 2. `go build` doesn't work on a fresh clone — closes #242

The README told readers to clone and run `go build`, which cannot work: the Go binaries embed `frontend/build`, so a fresh clone fails with `pattern all:frontend/build: no matching files found` — exactly what the reporter hit. It also advertised `go install`, which fails for the same reason, as `frontend/build` is gitignored.

Two make targets were stale as well:

- `build-cli` built the Wails GUI package at the repo root, **not** `./cmd/postie` that `release.yml` actually ships under that name.
- `build-client` pointed at `./cmd/main`, which no longer exists, so the target failed outright. Renamed to `build-web` against `./cmd/web`.

The docs now cover the real prerequisites (Bun, a C toolchain for the cgo PAR2 encoder, wails via `go tool wails` rather than a separate install) and the frontend-first build order.

## Test plan

- [x] `evaluateProviderAvailability` covered by 9 cases: historical vs. new errors, `ActiveConnections` override, first-observation seeding, multi-provider independence, baseline pruning on removal, nil baseline (the shape of the first real call), empty provider list.
- [x] Red-green verified — restoring the old `Errors == 0` condition fails exactly the tests encoding the bug; the fix makes them pass.
- [x] `go test -race ./internal/... ./pkg/...` — exit 0, 20 packages ok, 0 failures.
- [x] `go vet ./...` exit 0, `go build ./...` exit 0, `gofmt -l` clean.
- [x] `make build-frontend` then `make build` produces both binaries; `./postie-cli --help` now prints the CLI rather than launching the GUI.

Not covered by tests: the 30s monitor loop itself is unchanged and still untested — only the decision it makes is now under test.

> *Raised during AI-assisted triage of the open issue list.*
