### PR TITLE
fix(web): keep dashboard live when the WebSocket silently dies

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -12,27 +12,20 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/gorilla/websocket"
 	"github.com/kipsilabs/postie/frontend"
 	"github.com/kipsilabs/postie/internal/backend"
 	"github.com/kipsilabs/postie/internal/config"
+	"github.com/kipsilabs/postie/internal/wshub"
 	"github.com/spf13/cobra"
 )
 
 // For development, serve static files from disk
 // In production, these would be embedded
 var frontendBuildPath = "../../frontend/build"
-
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
-		return true // Allow all origins for now, should be configured properly
-	},
-}
 
 // ErrorResponse represents a structured error response
 type ErrorResponse struct {
@@ -59,139 +52,20 @@ var (
 	host string
 )
 
-// WebSocketClient represents a connected WebSocket client
-type WebSocketClient struct {
-	conn *websocket.Conn
-	send chan []byte
-	hub  *WebSocketHub
-	id   string
-}
-
-// WebSocketHub manages WebSocket connections and broadcasts
-type WebSocketHub struct {
-	clients    map[*WebSocketClient]bool
-	broadcast  chan []byte
-	register   chan *WebSocketClient
-	unregister chan *WebSocketClient
-	mu         sync.RWMutex
-}
-
-// WebSocketMessage represents a message sent over WebSocket
-type WebSocketMessage struct {
-	Type string `json:"type"`
-	Data any    `json:"data"`
-}
-
-// NewWebSocketHub creates a new WebSocket hub
-func NewWebSocketHub() *WebSocketHub {
-	return &WebSocketHub{
-		clients:    make(map[*WebSocketClient]bool),
-		broadcast:  make(chan []byte, 256),
-		register:   make(chan *WebSocketClient),
-		unregister: make(chan *WebSocketClient),
-	}
-}
-
-// Run starts the WebSocket hub
-func (h *WebSocketHub) Run() {
-	for {
-		select {
-		case client := <-h.register:
-			h.mu.Lock()
-			h.clients[client] = true
-			h.mu.Unlock()
-			slog.Info("WebSocket client connected", "id", client.id)
-
-		case client := <-h.unregister:
-			h.mu.Lock()
-			if _, ok := h.clients[client]; ok {
-				delete(h.clients, client)
-				close(client.send)
-				slog.Info("WebSocket client disconnected", "id", client.id)
-			}
-			h.mu.Unlock()
-
-		case message := <-h.broadcast:
-			h.mu.RLock()
-			for client := range h.clients {
-				select {
-				case client.send <- message:
-				default:
-					delete(h.clients, client)
-					close(client.send)
-				}
-			}
-			h.mu.RUnlock()
-		}
-	}
-}
-
-// EmitEvent sends an event to all connected clients
-func (h *WebSocketHub) EmitEvent(eventType string, data any) {
-	message := WebSocketMessage{
-		Type: eventType,
-		Data: data,
-	}
-
-	jsonData, err := json.Marshal(message)
-	if err != nil {
-		slog.Error("Error marshaling WebSocket message", "error", err)
-		return
-	}
-
-	select {
-	case h.broadcast <- jsonData:
-	default:
-		slog.Warn("WebSocket broadcast channel full, dropping message")
-	}
-}
-
-// readPump handles reading from the WebSocket connection
-func (c *WebSocketClient) readPump() {
-	defer func() {
-		c.hub.unregister <- c
-		_ = c.conn.Close()
-	}()
-
-	for {
-		_, _, err := c.conn.ReadMessage()
-		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				slog.Error("WebSocket error", "error", err)
-			}
-			break
-		}
-	}
-}
-
-// writePump handles writing to the WebSocket connection
-func (c *WebSocketClient) writePump() {
-	defer func() {
-		_ = c.conn.Close()
-	}()
-
-	for message := range c.send {
-		if err := c.conn.WriteMessage(websocket.TextMessage, message); err != nil {
-			slog.Error("WebSocket write error", "error", err)
-			return
-		}
-	}
-}
-
 // WebEventEmitter is a function that emits events for web mode
 type WebEventEmitter func(eventType string, data any)
 
 type WebServer struct {
 	app          *backend.App
 	router       *mux.Router
-	wsHub        *WebSocketHub
+	wsHub        *wshub.Hub
 	eventEmitter WebEventEmitter
 }
 
 func NewWebServer() *WebServer {
 	app := backend.NewApp()
 	router := mux.NewRouter()
-	wsHub := NewWebSocketHub()
+	wsHub := wshub.NewHub()
 
 	ws := &WebServer{
 		app:    app,
@@ -383,28 +257,7 @@ func (ws *WebServer) handleTriggerScan(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ws *WebServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		slog.Error("WebSocket upgrade error", "error", err)
-		return
-	}
-
-	slog.Info("WebSocket connection established successfully")
-
-	// Create client
-	client := &WebSocketClient{
-		conn: conn,
-		send: make(chan []byte, 256),
-		hub:  ws.wsHub,
-		id:   fmt.Sprintf("client-%s", conn.RemoteAddr().String()),
-	}
-
-	// Register client
-	ws.wsHub.register <- client
-
-	// Start client pumps
-	go client.writePump()
-	go client.readPump()
+	ws.wsHub.ServeHTTP(w, r)
 }
 
 func (ws *WebServer) handleGetStatus(w http.ResponseWriter, r *http.Request) {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -620,6 +620,28 @@ export class UnifiedClient {
 		}
 	}
 
+	// True when push events are flowing. Wails events cannot silently drop;
+	// in web mode this reflects the WebSocket state.
+	isLive(): boolean {
+		if (this._environment === "wails") return true;
+		if (this._environment === "web") return webClient?.isConnected() ?? false;
+		return false;
+	}
+
+	onReconnect(callback: () => void): () => void {
+		if (this._environment !== "web") return () => {};
+		let unsubscribe: (() => void) | undefined;
+		let cancelled = false;
+		getWebClient().then((client) => {
+			if (cancelled) return;
+			unsubscribe = client.onReconnect(callback);
+		});
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	}
+
 	// Queue Actions
 	async clearQueue(): Promise<void> {
 		await this.initialize();

--- a/frontend/src/lib/api/live-fallback.test.ts
+++ b/frontend/src/lib/api/live-fallback.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { startLiveFallback } from "./live-fallback";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("startLiveFallback", () => {
+	test("refreshes on the interval while the live channel is down", async () => {
+		let calls = 0;
+		const stop = startLiveFallback({
+			intervalMs: 10,
+			isLive: () => false,
+			refresh: () => {
+				calls++;
+			},
+		});
+		await sleep(65);
+		stop();
+		expect(calls).toBeGreaterThanOrEqual(3);
+	});
+
+	test("does not refresh while the live channel is up", async () => {
+		let calls = 0;
+		const stop = startLiveFallback({
+			intervalMs: 10,
+			isLive: () => true,
+			refresh: () => {
+				calls++;
+			},
+		});
+		await sleep(50);
+		stop();
+		expect(calls).toBe(0);
+	});
+
+	test("refreshes once immediately when the live channel reconnects", async () => {
+		let calls = 0;
+		let fire: (() => void) | undefined;
+		const stop = startLiveFallback({
+			intervalMs: 10_000,
+			isLive: () => true,
+			refresh: () => {
+				calls++;
+			},
+			onReconnect: (cb) => {
+				fire = cb;
+				return () => {
+					fire = undefined;
+				};
+			},
+		});
+		fire?.();
+		await sleep(5);
+		expect(calls).toBe(1);
+		stop();
+		expect(fire).toBeUndefined();
+	});
+
+	test("stop halts further refreshes", async () => {
+		let calls = 0;
+		const stop = startLiveFallback({
+			intervalMs: 10,
+			isLive: () => false,
+			refresh: () => {
+				calls++;
+			},
+		});
+		await sleep(25);
+		stop();
+		const after = calls;
+		await sleep(40);
+		expect(calls).toBe(after);
+	});
+});

--- a/frontend/src/lib/api/live-fallback.ts
+++ b/frontend/src/lib/api/live-fallback.ts
@@ -1,0 +1,34 @@
+export interface LiveFallbackOptions {
+	intervalMs: number;
+	isLive: () => boolean;
+	refresh: () => void | Promise<void>;
+	onReconnect?: (callback: () => void) => () => void;
+}
+
+// Event-driven panels go stale when the push channel silently dies (a half-open
+// WebSocket behind Docker/NAT, a proxy that never upgraded). This keeps them
+// honest: poll while the channel is down, and re-sync once when it comes back,
+// since the broadcaster only pushes running-jobs on change.
+export function startLiveFallback(options: LiveFallbackOptions): () => void {
+	const { intervalMs, isLive, refresh, onReconnect } = options;
+	let stopped = false;
+
+	const safeRefresh = () => {
+		if (stopped) return;
+		Promise.resolve()
+			.then(refresh)
+			.catch((error) => console.error("Live fallback refresh failed:", error));
+	};
+
+	const timer = setInterval(() => {
+		if (!isLive()) safeRefresh();
+	}, intervalMs);
+
+	const unsubscribe = onReconnect?.(safeRefresh);
+
+	return () => {
+		stopped = true;
+		clearInterval(timer);
+		unsubscribe?.();
+	};
+}

--- a/frontend/src/lib/api/web-client.ts
+++ b/frontend/src/lib/api/web-client.ts
@@ -19,6 +19,7 @@ export interface ArrInstance {
 export class WebClient {
 	private ws: WebSocket | null = null;
 	private wsListeners: Map<string, (data: unknown) => void> = new Map();
+	private reconnectListeners = new Set<() => void>();
 
 	constructor() {
 		this.initWebSocket();
@@ -59,6 +60,9 @@ export class WebClient {
 
 		this.ws.onopen = (event) => {
 			console.log("WebSocket connected successfully", event);
+			for (const listener of this.reconnectListeners) {
+				listener();
+			}
 		};
 
 		this.ws.onmessage = (event) => {
@@ -113,6 +117,18 @@ export class WebClient {
 	// Remove event listener
 	off(event: string) {
 		this.wsListeners.delete(event);
+	}
+
+	isConnected(): boolean {
+		return this.ws?.readyState === WebSocket.OPEN;
+	}
+
+	// Fires on every successful (re)connection so event-driven views can re-sync.
+	onReconnect(callback: () => void): () => void {
+		this.reconnectListeners.add(callback);
+		return () => {
+			this.reconnectListeners.delete(callback);
+		};
 	}
 
 	// Requests that hang (e.g. the backend blocked on the database during a

--- a/frontend/src/lib/components/dashboard/ProgressSection.svelte
+++ b/frontend/src/lib/components/dashboard/ProgressSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import { startLiveFallback } from "$lib/api/live-fallback";
 import {
   EVENT_PROCESSING_AUTO_PAUSED,
   EVENT_PROCESSING_PAUSED,
@@ -17,6 +18,7 @@ import { onMount, onDestroy } from "svelte";
 
 let isPaused = $state(false);
 let destroyed = false;
+let stopFallback: (() => void) | undefined;
 
 function applyRunningJobs(data: unknown) {
   if (destroyed) return;
@@ -52,10 +54,17 @@ onMount(async () => {
   await apiClient.on(EVENT_PROCESSING_PAUSED, applyPauseEvent);
   await apiClient.on(EVENT_PROCESSING_RESUMED, applyPauseEvent);
   await apiClient.on(EVENT_PROCESSING_AUTO_PAUSED, applyPauseEvent);
+  stopFallback = startLiveFallback({
+    intervalMs: 5000,
+    isLive: () => apiClient.isLive(),
+    refresh: fetchInitialState,
+    onReconnect: (cb) => apiClient.onReconnect(cb),
+  });
 });
 
 onDestroy(() => {
   destroyed = true;
+  stopFallback?.();
   apiClient.off(EVENT_RUNNING_JOBS_UPDATED, applyRunningJobs);
   apiClient.off(EVENT_PROCESSING_PAUSED, applyPauseEvent);
   apiClient.off(EVENT_PROCESSING_RESUMED, applyPauseEvent);

--- a/frontend/src/lib/components/dashboard/ProviderStatus.svelte
+++ b/frontend/src/lib/components/dashboard/ProviderStatus.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import apiClient from "$lib/api/client";
+import { startLiveFallback } from "$lib/api/live-fallback";
 import {
 	EVENT_NNTP_POOL_METRICS_UPDATED,
 	type NntpPoolMetricsEvent,
@@ -13,6 +14,7 @@ import { onDestroy, onMount } from "svelte";
 let poolMetrics = $state<backend.NntpPoolMetrics | null>(null);
 let initialLoad = $state(true);
 let error = $state("");
+let stopFallback: (() => void) | undefined;
 
 function applyPoolMetrics(data: unknown) {
 	if (!data) return;
@@ -79,9 +81,16 @@ function formatSpeed(bytesPerSec: number): string {
 onMount(async () => {
 	await fetchProviderStatus();
 	await apiClient.on(EVENT_NNTP_POOL_METRICS_UPDATED, applyPoolMetrics);
+	stopFallback = startLiveFallback({
+		intervalMs: 5000,
+		isLive: () => apiClient.isLive(),
+		refresh: fetchProviderStatus,
+		onReconnect: (cb) => apiClient.onReconnect(cb),
+	});
 });
 
 onDestroy(() => {
+	stopFallback?.();
 	apiClient.off(EVENT_NNTP_POOL_METRICS_UPDATED, applyPoolMetrics);
 });
 </script>

--- a/internal/wshub/hub.go
+++ b/internal/wshub/hub.go
@@ -1,0 +1,196 @@
+// Package wshub fans backend events out to browser clients over WebSocket in
+// web mode.
+package wshub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	defaultPingInterval   = 30 * time.Second
+	defaultPongWait       = 60 * time.Second
+	defaultWriteWait      = 10 * time.Second
+	defaultSendBufferSize = 256
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+type client struct {
+	conn *websocket.Conn
+	send chan []byte
+	hub  *Hub
+	id   string
+}
+
+// Hub manages WebSocket connections and broadcasts events to all of them.
+type Hub struct {
+	clients    map[*client]bool
+	broadcast  chan []byte
+	register   chan *client
+	unregister chan *client
+	mu         sync.RWMutex
+
+	pingInterval time.Duration
+	pongWait     time.Duration
+	writeWait    time.Duration
+}
+
+type message struct {
+	Type string `json:"type"`
+	Data any    `json:"data"`
+}
+
+// NewHub creates a hub. Call Run in its own goroutine before serving clients.
+func NewHub() *Hub {
+	return &Hub{
+		clients:      make(map[*client]bool),
+		broadcast:    make(chan []byte, 256),
+		register:     make(chan *client),
+		unregister:   make(chan *client),
+		pingInterval: defaultPingInterval,
+		pongWait:     defaultPongWait,
+		writeWait:    defaultWriteWait,
+	}
+}
+
+// Run drives registration and broadcast. It never returns.
+func (h *Hub) Run() {
+	for {
+		select {
+		case c := <-h.register:
+			h.mu.Lock()
+			h.clients[c] = true
+			h.mu.Unlock()
+			slog.Info("WebSocket client connected", "id", c.id)
+
+		case c := <-h.unregister:
+			h.mu.Lock()
+			if _, ok := h.clients[c]; ok {
+				delete(h.clients, c)
+				close(c.send)
+				slog.Info("WebSocket client disconnected", "id", c.id)
+			}
+			h.mu.Unlock()
+
+		case msg := <-h.broadcast:
+			h.mu.Lock()
+			for c := range h.clients {
+				select {
+				case c.send <- msg:
+				default:
+					// A peer that stopped draining is dead or hopelessly behind;
+					// drop it so one stalled tab cannot hold the hub.
+					delete(h.clients, c)
+					close(c.send)
+					slog.Warn("WebSocket client too slow, dropping", "id", c.id)
+				}
+			}
+			h.mu.Unlock()
+		}
+	}
+}
+
+// EmitEvent sends an event to all connected clients.
+func (h *Hub) EmitEvent(eventType string, data any) {
+	payload, err := json.Marshal(message{Type: eventType, Data: data})
+	if err != nil {
+		slog.Error("Error marshaling WebSocket message", "error", err)
+		return
+	}
+
+	select {
+	case h.broadcast <- payload:
+	default:
+		slog.Warn("WebSocket broadcast channel full, dropping message")
+	}
+}
+
+// ServeHTTP upgrades the request and attaches the connection to the hub.
+func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		slog.Error("WebSocket upgrade error", "error", err)
+		return
+	}
+
+	c := &client{
+		conn: conn,
+		send: make(chan []byte, defaultSendBufferSize),
+		hub:  h,
+		id:   fmt.Sprintf("client-%s", conn.RemoteAddr().String()),
+	}
+	h.register <- c
+
+	go c.writePump()
+	go c.readPump()
+}
+
+func (c *client) readPump() {
+	defer func() {
+		c.hub.unregister <- c
+		_ = c.conn.Close()
+	}()
+
+	// Without a read deadline a half-open TCP connection (NAT timeout, proxy
+	// idle cut) never errors, and the browser side never learns to reconnect.
+	// Pongs push the deadline forward; silence past pongWait ends the client.
+	_ = c.conn.SetReadDeadline(time.Now().Add(c.hub.pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		return c.conn.SetReadDeadline(time.Now().Add(c.hub.pongWait))
+	})
+
+	for {
+		if _, _, err := c.conn.ReadMessage(); err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				slog.Debug("WebSocket read ended", "id", c.id, "error", err)
+			}
+			return
+		}
+	}
+}
+
+func (c *client) writePump() {
+	ticker := time.NewTicker(c.hub.pingInterval)
+	defer func() {
+		ticker.Stop()
+		_ = c.conn.Close()
+	}()
+
+	for {
+		select {
+		case msg, ok := <-c.send:
+			if !ok {
+				return
+			}
+			if err := c.write(websocket.TextMessage, msg); err != nil {
+				slog.Debug("WebSocket write failed", "id", c.id, "error", err)
+				return
+			}
+		case <-ticker.C:
+			if err := c.write(websocket.PingMessage, nil); err != nil {
+				slog.Debug("WebSocket ping failed", "id", c.id, "error", err)
+				return
+			}
+		}
+	}
+}
+
+func (c *client) write(messageType int, payload []byte) error {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.hub.writeWait)); err != nil {
+		return err
+	}
+	return c.conn.WriteMessage(messageType, payload)
+}

--- a/internal/wshub/hub_test.go
+++ b/internal/wshub/hub_test.go
@@ -1,0 +1,114 @@
+package wshub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func newTestHub(t *testing.T, ping, pongWait time.Duration) (*Hub, *httptest.Server) {
+	t.Helper()
+	hub := NewHub()
+	hub.pingInterval = ping
+	hub.pongWait = pongWait
+	go hub.Run()
+	srv := httptest.NewServer(http.HandlerFunc(hub.ServeHTTP))
+	t.Cleanup(srv.Close)
+	return hub, srv
+}
+
+func dial(t *testing.T, srv *httptest.Server) *websocket.Conn {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func TestHubSendsPingsToConnectedClient(t *testing.T) {
+	_, srv := newTestHub(t, 20*time.Millisecond, time.Second)
+	conn := dial(t, srv)
+
+	pinged := make(chan struct{}, 1)
+	conn.SetPingHandler(func(string) error {
+		select {
+		case pinged <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-pinged:
+	case <-time.After(time.Second):
+		t.Fatal("server never sent a ping frame")
+	}
+}
+
+func TestHubClosesClientThatStopsAnsweringPings(t *testing.T) {
+	_, srv := newTestHub(t, 20*time.Millisecond, 100*time.Millisecond)
+	conn := dial(t, srv)
+
+	// A half-dead peer: frames still arrive but nothing is ever answered.
+	conn.SetPingHandler(func(string) error { return nil })
+
+	closed := make(chan error, 1)
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				closed <- err
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server kept a client that never answered pings")
+	}
+}
+
+func TestHubDeliversEventsAfterReconnect(t *testing.T) {
+	hub, srv := newTestHub(t, time.Hour, time.Hour)
+	first := dial(t, srv)
+	_ = first.Close()
+
+	second := dial(t, srv)
+	got := make(chan string, 1)
+	go func() {
+		_, msg, err := second.ReadMessage()
+		if err == nil {
+			got <- string(msg)
+		}
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		hub.EmitEvent("nntp-pool-metrics-updated", map[string]int{"n": 1})
+		select {
+		case msg := <-got:
+			if !strings.Contains(msg, "nntp-pool-metrics-updated") {
+				t.Fatalf("unexpected message %q", msg)
+			}
+			return
+		case <-deadline:
+			t.Fatal("reconnected client received no events")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
Stack 1/3 for the dashboard report in #184 (Oleekae, 2026-09-06) and #168.

## Problem
Upload Progress and Provider Status only refreshed via WebSocket events. A half-open connection (Docker NAT, proxy idle cut) or a failed upgrade left them frozen until a manual reload, while the polled Queue Statistics kept updating. That is exactly the asymmetry the tester describes.

## Changes
- Extract the hub into `internal/wshub` so it is covered by the CI `./internal/...` sweep.
- Add ping/pong keepalive with read and write deadlines so dead peers are detected server-side and the browser gets a close and reconnects.
- `startLiveFallback` helper: both panels poll every 5s while the push channel is down and re-sync once on reconnect (running-jobs events are only pushed on change).
- `apiClient.isLive()` / `onReconnect()` (Wails is always live).

## Tests
- `go test -race ./internal/wshub` (ping delivery, dead-peer eviction, delivery after reconnect)
- `bun test frontend/src/lib/api/live-fallback.test.ts`
- `bun run check` (only the 2 pre-existing errors in untouched files), `bun run build`

Refs #184 #168