### PR TITLE
fix(dashboard): stop misreporting provider state, inflight and totals

### DIFF
--- a/frontend/src/lib/components/dashboard/ProviderStatus.svelte
+++ b/frontend/src/lib/components/dashboard/ProviderStatus.svelte
@@ -6,12 +6,33 @@ import {
 	type NntpPoolMetricsEvent,
 } from "$lib/api/events";
 import { t } from "$lib/i18n";
+import { classifyProvider, type ProviderSnapshot, type ProviderState } from "$lib/provider-status";
 import { backend } from "$lib/wailsjs/go/models";
 import { CheckCircle, Clock, AlertCircle, Server, WifiOff } from "lucide-svelte";
 import { onDestroy, onMount } from "svelte";
   import { formatElapsed } from '$lib/utils';
 
 let poolMetrics = $state<backend.NntpPoolMetrics | null>(null);
+let previousByHost = new Map<string, ProviderSnapshot>();
+let statesByHost = $state<Map<string, ProviderState>>(new Map());
+
+function updateStates(metrics: backend.NntpPoolMetrics | null) {
+	const next = new Map<string, ProviderState>();
+	const seen = new Map<string, ProviderSnapshot>();
+	for (const provider of metrics?.providers ?? []) {
+		next.set(provider.host, classifyProvider(provider, previousByHost.get(provider.host)));
+		seen.set(provider.host, {
+			activeConnections: provider.activeConnections,
+			totalErrors: provider.totalErrors,
+		});
+	}
+	previousByHost = seen;
+	statesByHost = next;
+}
+
+function stateOf(provider: backend.NntpProviderMetrics): ProviderState {
+	return statesByHost.get(provider.host) ?? "idle";
+}
 let initialLoad = $state(true);
 let error = $state("");
 let stopFallback: (() => void) | undefined;
@@ -19,6 +40,7 @@ let stopFallback: (() => void) | undefined;
 function applyPoolMetrics(data: unknown) {
 	if (!data) return;
 	poolMetrics = data as NntpPoolMetricsEvent;
+	updateStates(poolMetrics);
 	error = "";
 }
 
@@ -26,6 +48,7 @@ async function fetchProviderStatus() {
 	try {
 		error = "";
 		poolMetrics = await apiClient.getNntpPoolMetrics();
+		updateStates(poolMetrics);
 	} catch (err) {
 		console.error("Failed to fetch provider status:", err);
 		error = String(err);
@@ -36,33 +59,29 @@ async function fetchProviderStatus() {
 }
 
 function getProviderStatusIcon(provider: backend.NntpProviderMetrics) {
-	if (provider.activeConnections > 0) {
-		return CheckCircle;
+	switch (stateOf(provider)) {
+		case "connected":
+			return CheckCircle;
+		case "failed":
+			return AlertCircle;
+		default:
+			return Clock;
 	}
-	if (provider.totalErrors > 0) {
-		return AlertCircle;
-	}
-	return Clock;
 }
 
 function getProviderStatusClass(provider: backend.NntpProviderMetrics) {
-	if (provider.activeConnections > 0) {
-		return "text-success";
+	switch (stateOf(provider)) {
+		case "connected":
+			return "text-success";
+		case "failed":
+			return "text-error";
+		default:
+			return "text-base-content/50";
 	}
-	if (provider.totalErrors > 0 && provider.activeConnections === 0) {
-		return "text-error";
-	}
-	return "text-base-content/50";
 }
 
 function getProviderStatusText(provider: backend.NntpProviderMetrics) {
-	if (provider.activeConnections > 0) {
-		return $t("dashboard.provider.status.connected");
-	}
-	if (provider.totalErrors > 0 && provider.activeConnections === 0) {
-		return $t("dashboard.provider.status.failed");
-	}
-	return $t("dashboard.provider.status.idle");
+	return $t(`dashboard.provider.status.${stateOf(provider)}`);
 }
 
 function formatBytes(bytes: number): string {
@@ -157,7 +176,7 @@ onDestroy(() => {
 							</div>
 							<div>
 								<span class="text-base-content/70">{$t("dashboard.provider.inflight")}:</span>
-								<span class="font-medium ml-1">{provider.inflight || 10}</span>
+								<span class="font-medium ml-1">{provider.inflight}</span>
 							</div>
 							<div>
 								<span class="text-base-content/70">{$t("dashboard.provider.missing")}:</span>

--- a/frontend/src/lib/locales/en/dashboard.json
+++ b/frontend/src/lib/locales/en/dashboard.json
@@ -190,7 +190,7 @@
 			"active_connections": "active connections",
 			"total_errors": "Total Errors",
 			"no_providers": "No providers configured",
-			"inflight": "Inflight",
+			"inflight": "Pipeline depth",
 			"current_speed": "Current Speed",
 			"ttfb": "TTFB",
 			"downloaded": "Downloaded",

--- a/frontend/src/lib/locales/es/dashboard.json
+++ b/frontend/src/lib/locales/es/dashboard.json
@@ -192,7 +192,7 @@
 			"active_connections": "conexiones activas",
 			"total_errors": "Errores Totales",
 			"no_providers": "No hay proveedores configurados",
-			"inflight": "En vuelo",
+			"inflight": "Profundidad de pipeline",
 			"current_speed": "Velocidad Actual",
 			"ttfb": "TTFB",
 			"downloaded": "Descargado",

--- a/frontend/src/lib/locales/fr/dashboard.json
+++ b/frontend/src/lib/locales/fr/dashboard.json
@@ -196,7 +196,7 @@
 			"errors": "Erreurs",
 			"elapsed": "Disponibilité",
 			"total_errors": "Erreurs Totales",
-			"inflight": "En cours",
+			"inflight": "Profondeur du pipeline",
 			"current_speed": "Vitesse Actuelle",
 			"ttfb": "TTFB",
 			"downloaded": "Téléchargé",
@@ -206,6 +206,7 @@
 			"quota_resets": "Réinitialisation",
 			"status": {
 				"connected": "Connecté",
+				"idle": "Inactif",
 				"connecting": "Connexion",
 				"reconnecting": "Reconnexion",
 				"failed": "Échec",

--- a/frontend/src/lib/locales/tr/dashboard.json
+++ b/frontend/src/lib/locales/tr/dashboard.json
@@ -195,7 +195,7 @@
             "errors": "Hatalar",
             "elapsed": "Çalışma Süresi",
             "total_errors": "Toplam Hata",
-            "inflight": "Eşzamanlı",
+            "inflight": "Pipeline derinliği",
             "current_speed": "Anlık Hız",
             "ttfb": "TTFB",
             "downloaded": "İndirilen",
@@ -205,6 +205,7 @@
             "quota_resets": "Sıfırlanma",
             "status": {
                 "connected": "Bağlandı",
+                "idle": "Boşta",
                 "connecting": "Bağlanıyor",
                 "reconnecting": "Yeniden Bağlanıyor",
                 "failed": "Başarısız",

--- a/frontend/src/lib/provider-status.test.ts
+++ b/frontend/src/lib/provider-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { classifyProvider, type ProviderSnapshot } from "./provider-status";
+
+const snap = (over: Partial<ProviderSnapshot>): ProviderSnapshot => ({
+	activeConnections: 0,
+	totalErrors: 0,
+	...over,
+});
+
+describe("classifyProvider", () => {
+	test("connected while it holds active connections", () => {
+		expect(classifyProvider(snap({ activeConnections: 3, totalErrors: 500 }))).toBe("connected");
+	});
+
+	test("idle when nothing is in flight, even with historical errors", () => {
+		const previous = snap({ totalErrors: 109 });
+		expect(classifyProvider(snap({ totalErrors: 109 }), previous)).toBe("idle");
+	});
+
+	test("idle with no history to compare against", () => {
+		expect(classifyProvider(snap({ totalErrors: 109 }))).toBe("idle");
+	});
+
+	test("failed when errors keep growing without any connection", () => {
+		const previous = snap({ totalErrors: 100 });
+		expect(classifyProvider(snap({ totalErrors: 104 }), previous)).toBe("failed");
+	});
+});

--- a/frontend/src/lib/provider-status.ts
+++ b/frontend/src/lib/provider-status.ts
@@ -1,0 +1,19 @@
+export interface ProviderSnapshot {
+	activeConnections: number;
+	totalErrors: number;
+}
+
+export type ProviderState = "connected" | "idle" | "failed";
+
+// nntppool only exposes a lifetime error counter, so a provider that retried a
+// few hundred articles over a multi-terabyte run would read "Failed" forever
+// once its connections went idle. Only a counter that is still climbing while
+// nothing is connected means the provider is actually unhealthy right now.
+export function classifyProvider(
+	current: ProviderSnapshot,
+	previous?: ProviderSnapshot,
+): ProviderState {
+	if (current.activeConnections > 0) return "connected";
+	if (previous && current.totalErrors > previous.totalErrors) return "failed";
+	return "idle";
+}

--- a/internal/backend/queue.go
+++ b/internal/backend/queue.go
@@ -327,7 +327,9 @@ func (a *App) GetQueueStats() (QueueStats, error) {
 	// Convert map[string]interface{} to QueueStats struct
 	queueStats := QueueStats{}
 
-	if total, ok := stats["total"].(int); ok {
+	// The dashboard card reads "Total Items"; the queue's own "total" is only
+	// the live backlog, which drops to 0 the moment a batch finishes.
+	if total, ok := stats["total_including_completed"].(int); ok {
 		queueStats.Total = total
 	}
 	if pending, ok := stats["pending"].(int); ok {

--- a/internal/backend/queue_test.go
+++ b/internal/backend/queue_test.go
@@ -88,3 +88,31 @@ func TestRemoveFromQueue_RemovesPendingItemAndEmitsEvent(t *testing.T) {
 		t.Fatalf("expected one queue-updated event, got %v", events)
 	}
 }
+
+func TestGetQueueStats_TotalCountsEveryItemEverSeen(t *testing.T) {
+	q := newTestQueue(t)
+	ctx := context.Background()
+	if err := q.AddFile(ctx, filepath.Join(t.TempDir(), "pending.bin"), 10); err != nil {
+		t.Fatalf("AddFile: %v", err)
+	}
+	for _, id := range []string{"c1", "c2"} {
+		if _, err := q.DB().ExecContext(ctx, `INSERT INTO completed_items
+			(id, path, size, nzb_path, created_at, job_data, verification_status)
+			VALUES (?,?,?,?,?,?,?)`,
+			id, "/d/"+id, 1, "/o/"+id+".nzb", "2026-01-01T00:00:00Z", []byte("{}"), "verified"); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	app := &App{queue: q}
+	stats, err := app.GetQueueStats()
+	if err != nil {
+		t.Fatalf("GetQueueStats: %v", err)
+	}
+	if stats.Pending != 1 || stats.Complete != 2 {
+		t.Fatalf("pending=%d complete=%d, want 1/2", stats.Pending, stats.Complete)
+	}
+	if stats.Total != 3 {
+		t.Errorf("Total = %d, want 3 (pending + running + complete + errored)", stats.Total)
+	}
+}


### PR DESCRIPTION
Stack 2/3 for #184 / #168. Based on `fix/web-ws-keepalive-fallback`; retarget to `main` once that merges.

## Problem
After a clean 1.9 TB run the dashboard still read as broken (screenshots in #184):
- every provider showed **Failed** with 0/90 connections
- **Inflight: 10** on every provider
- **Total Items 0** next to **Complete 18023**

## Changes
- `classifyProvider`: Connected while it has active connections; Failed only when the lifetime error counter is still climbing with no connections; otherwise Idle. Previously any historical error count meant Failed forever.
- Inflight was `provider.inflight || 10`. It is the configured pipeline depth, so show the real value under a "Pipeline depth" label.
- `Total` in `QueueStats` now maps from the lifetime total (pending + running + complete + errored) instead of the live backlog.
- Add the missing `status.idle` translation to fr and tr.

## Tests
- `go test ./internal/backend` (`TestGetQueueStats_TotalCountsEveryItemEverSeen`)
- `bun test frontend/src/lib/provider-status.test.ts`

Refs #184 #168