### PR TITLE
docs: add PowerShell post-upload script example

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -370,6 +370,15 @@ post_upload_script:
   timeout: 30s
 ```
 
+Example running a PowerShell script on Windows:
+
+```yaml
+post_upload_script:
+  enabled: true
+  command: 'powershell C:\Usenet_Programms\Postie\Scripts\ZIP.ps1 {nzb_path}'
+  timeout: 30s
+```
+
 **💡 Tip: The web UI allows you to test your post-upload scripts and provides examples for common use cases.**
 
 ### Global Settings


### PR DESCRIPTION
## Summary
- Adds a Windows/PowerShell example to the `post_upload_script` docs section in `docs/docs/configuration.md`, alongside the existing curl webhook example.
- Closes #55, where a user was unsure how to invoke a PowerShell script and eventually [figured it out themselves](https://github.com/kipsilabs/postie/issues/55#issuecomment-latest), suggesting it be added to the docs.

Closes #55

## Test plan
- [x] Rendered the markdown locally to confirm the new code block is well-formed
- [ ] N/A — docs-only change, no functional code touched