### PR TITLE
fix(desktop): make drag & drop work on Windows

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -18,6 +18,8 @@ let needsConfiguration = false;
 let criticalConfigError = false;
 let isDragOver = false;
 let dragCounter = 0;
+let fileDropOff: (() => void) | null = null;
+let destroyed = false;
 
 onMount(() => {
 	// Set up drag over detection for UI feedback
@@ -25,6 +27,8 @@ onMount(() => {
 	window.addEventListener("dragleave", handleDragLeave);
 	window.addEventListener("dragover", handleDragOver);
 	window.addEventListener("drop", handleDrop);
+
+	registerWailsFileDrop();
 
 	// Listen for file drop events from backend
 	apiClient.on("file-drop-success", () => {
@@ -93,7 +97,37 @@ onDestroy(() => {
 	window.removeEventListener("dragleave", handleDragLeave);
 	window.removeEventListener("dragover", handleDragOver);
 	window.removeEventListener("drop", handleDrop);
+
+	destroyed = true;
+	fileDropOff?.();
+	fileDropOff = null;
 });
+
+// On Windows the Go-side OnFileDrop handler only ever fires if the JS runtime
+// installs its own drop listener, which is what posts the dropped files back to
+// the webview. Registering here is what makes drag & drop work on Windows.
+async function registerWailsFileDrop() {
+	if (apiClient.environment !== "wails") {
+		return;
+	}
+
+	try {
+		const { OnFileDrop, OnFileDropOff } = await import(
+			"$lib/wailsjs/runtime/runtime"
+		);
+
+		if (destroyed) {
+			return;
+		}
+
+		// useDropTarget: false — the default re-checks elementFromPoint against
+		// --wails-drop-target, which our conditionally rendered overlay breaks.
+		OnFileDrop(() => {}, false);
+		fileDropOff = OnFileDropOff;
+	} catch (error) {
+		console.error("Failed to register Wails file drop handler:", error);
+	}
+}
 
 function handleDragEnter(e: DragEvent) {
 	e.preventDefault();

--- a/main.go
+++ b/main.go
@@ -165,8 +165,11 @@ func main() {
 		EnableDefaultContextMenu: true,
 		Menu:                     appMenu,
 		DragAndDrop: &options.DragAndDrop{
-			EnableFileDrop:     true,
-			DisableWebViewDrop: true,
+			EnableFileDrop: true,
+			// Windows has no native drop handler: the only path to wails:file-drop is the
+			// webview's JS drop event posting the files back to Go. Disabling the webview
+			// drop there calls AllowExternalDrag(false) and kills that path entirely.
+			DisableWebViewDrop: runtime.GOOS != "windows",
 			CSSDropProperty:    "--wails-drop-target",
 			CSSDropValue:       "drop",
 		},


### PR DESCRIPTION
## Summary

Fixes Windows drag & drop (#114) without moving to the Wails v3 alpha/beta. The failure was postie's own wiring, not the upstream WebView2 bug the issue assumed.

## Root cause

The two platforms reach the same `wails:file-drop` event by completely different routes:

- **macOS/Linux** — the drop is handled natively in the window (`darwin/WailsWebView.m` `performDragOperation:`, GTK on Linux) and emits `wails:file-drop` directly. No JS involved, which is why `runtime.OnFileDrop` in `main.go` worked there.
- **Windows** — there is no native handler. The only route is JS: a `drop` listener calls `chrome.webview.postMessageWithAdditionalObjects("file:drop:x:y", files)`, and `windows/frontend.go` turns that message into `wails:file-drop`.

That JS listener is installed **only inside the JS runtime's `OnFileDrop()`**, which the frontend never called — `+page.svelte` registered its own `drop` handler that stops navigation but posts nothing back. So on Windows nothing ever reached Go.

Second, independent blocker: `DisableWebViewDrop: true` calls `chromium.AllowExternalDrag(false)` on Windows, so the webview refuses the external drag outright and no JS `drop` event fires at all.

## Changes

- `frontend/src/routes/+page.svelte` — `registerWailsFileDrop()` on mount dynamically imports the Wails runtime and calls `OnFileDrop(() => {}, false)`. The callback is intentionally empty; the work still happens in the Go handler. `useDropTarget: false` because the default re-checks `document.elementFromPoint` against `--wails-drop-target`, which the conditionally rendered drag overlay breaks. `OnFileDropOff` runs on destroy, guarded by a `destroyed` flag so a late-resolving import can't register after teardown. Web mode short-circuits before the import.
- `main.go` — `DisableWebViewDrop` is now `runtime.GOOS != "windows"`.

## Notes

Wails v2.14.0 is out but contains only a WebView2 bootstrapper fix, nothing drag-related. v3 would mean a full API migration (`EnableFileDrop`, `data-file-drop-target`, `WindowFilesDropped`) for a problem we don't have.

## Test plan

- [x] `gofmt -l main.go` clean, `go vet ./...` clean, host `go build ./...` passes
- [x] `bun run build` succeeds; the dynamic import resolves
- [x] `bun run check` — 2 errors, both pre-existing and in untouched files (`ServerSection` `ServerData.name`, `DashboardHeader` `count` in `MessageObject`)
- [ ] **Needs a real Windows build to verify behavior** — this cannot be confirmed on macOS. Cross-compiling with `GOOS=windows` fails on unrelated cgo deps (`rapidyenc`, `par2go/internal/parpar`).
- [ ] Confirm macOS/Linux drop still works (native path should be untouched)

If the drop lands but the overlay stays stuck visible, that's [wails#5780](https://github.com/wailsapp/wails/issues/5780), separate from this fix.