### PR TITLE
fix(par2): verify existing PAR2 sets describe the source before reusing them

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -47,7 +47,8 @@ post_check:
 par2:
   enabled: true
   redundancy: '10%'
-  # Directory where PAR2 files are temporarily created (uses system temp by default)
+  # Directory where PAR2 files are temporarily created (uses system temp by default).
+  # Postie writes into a postie-par2/ subfolder there and sweeps orphaned sets older than 24h.
   temp_dir: ''
   # Whether to keep PAR2 files after successful upload (false = cleanup after success)
   maintain_par2_files: false

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -91,7 +91,7 @@ post_check:
 par2:
   enabled: true
   redundancy: "1n*1.2" # ParPar redundancy expression (default: "1n*1.2"); percentage format also accepted (e.g. "10%")
-  temp_dir: "" # Optional temporary directory for PAR2 operations
+  temp_dir: "" # Optional temporary directory for PAR2 operations. Generated files go into a postie-par2/ subfolder there; orphaned sets older than 24h are swept hourly. Empty: PAR2 files are written next to the sources.
   maintain_par2_files: false # Keep PAR2 files after successful upload
   parpar_binary_path: "" # Path to external parpar binary (empty = use built-in)
   gf16_method: auto # GF16 SIMD kernel for the built-in generator. Leave on auto unless troubleshooting; a kernel the CPU lacks makes PAR2 creation fail. Options: auto, lookup, lookup3, shuffle-avx2, shuffle-avx512, shuffle-vbmi, xor-jit-avx2, affine-avx2, affine-avx512, shuffle-neon, clmul-neon
@@ -260,7 +260,7 @@ Configure PAR2 recovery file generation:
 par2:
   enabled: true
   redundancy: "1n*1.2" # ParPar redundancy expression (default: "1n*1.2"); percentage also accepted (e.g. "10%")
-  temp_dir: "" # Optional temporary directory for PAR2 operations
+  temp_dir: "" # Optional temporary directory for PAR2 operations. Generated files go into a postie-par2/ subfolder there; orphaned sets older than 24h are swept hourly. Empty: PAR2 files are written next to the sources.
   maintain_par2_files: false # Keep PAR2 files after successful upload
   parpar_binary_path: "" # Path to external parpar binary (empty = use built-in)
   gf16_method: auto # GF16 SIMD kernel for the built-in generator. Leave on auto unless troubleshooting; a kernel the CPU lacks makes PAR2 creation fail. Options: auto, lookup, lookup3, shuffle-avx2, shuffle-avx512, shuffle-vbmi, xor-jit-avx2, affine-avx2, affine-avx512, shuffle-neon, clmul-neon

--- a/internal/par2/binary.go
+++ b/internal/par2/binary.go
@@ -77,7 +77,8 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		return nil, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
 	}
 
-	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath); ok {
+	// Reuse an existing set only if it was built from exactly these files.
+	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath, setInputNames(inputs, folderDir)); ok {
 		return existing, nil
 	}
 
@@ -192,7 +193,7 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		b.jobProgress.FinishProgress(progressID)
 	}
 
-	return collectPar2SetFiles(ctx, dirPath, setName, outputBase+".par2"), nil
+	return par2SetOnDisk(ctx, dirPath, setName), nil
 }
 
 // CreateInDirectory creates PAR2 files in the specified output directory using the parpar binary.
@@ -329,27 +330,12 @@ func (b *BinaryExecutor) runParpar(ctx context.Context, file fileinfo.FileInfo, 
 		b.jobProgress.FinishProgress(progressID)
 	}
 
-	// Collect output files
-	var created []string
-	mainPar2 := outputBase + ".par2"
-	if _, statErr := os.Stat(mainPar2); statErr == nil {
-		created = append(created, mainPar2)
+	// Collect output files (main + volumes named exactly after this file)
+	if _, statErr := os.Stat(outputBase + ".par2"); statErr != nil {
+		slog.WarnContext(ctx, "Parpar finished but main PAR2 file is missing", "path", outputBase+".par2", "error", statErr)
+		return nil, nil
 	}
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to read dir after parpar", "error", err)
-		return created, nil
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasPrefix(name, baseName) && strings.Contains(name, ".vol") && strings.HasSuffix(name, ".par2") {
-			created = append(created, filepath.Join(dirPath, name))
-		}
-	}
-	return created, nil
+	return par2SetOnDisk(ctx, dirPath, baseName), nil
 }
 
 // splitOnCROrLF is a bufio.SplitFunc that splits on either \r or \n.

--- a/internal/par2/binary.go
+++ b/internal/par2/binary.go
@@ -37,7 +37,7 @@ func NewBinaryExecutor(articleSize uint64, cfg *config.Par2Config, jobProgress p
 }
 
 // Create creates PAR2 parity files using the parpar binary.
-func (b *BinaryExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) ([]string, error) {
+func (b *BinaryExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) (Result, error) {
 	return b.CreateInDirectory(ctx, files, "")
 }
 
@@ -46,12 +46,12 @@ func (b *BinaryExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) 
 // folderDir as --filepath-base so parpar records each file's path relative
 // to folderDir in the FileDesc packet, letting SABnzbd / NZBGet recreate
 // the folder tree inside the job directory on disk.
-func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) ([]string, error) {
+func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) (Result, error) {
 	if len(files) == 0 {
-		return nil, fmt.Errorf("par2: no input files for set %q", setName)
+		return Result{}, fmt.Errorf("par2: no input files for set %q", setName)
 	}
 	if setName == "" {
-		return nil, fmt.Errorf("par2: empty set name")
+		return Result{}, fmt.Errorf("par2: empty set name")
 	}
 
 	inputs := make([]fileinfo.FileInfo, 0, len(files))
@@ -62,7 +62,7 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		inputs = append(inputs, f)
 	}
 	if len(inputs) == 0 {
-		return nil, fmt.Errorf("par2: no non-par2 input files for set %q", setName)
+		return Result{}, fmt.Errorf("par2: no non-par2 input files for set %q", setName)
 	}
 
 	dirPath := outputDir
@@ -74,12 +74,12 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		}
 	}
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		return nil, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
+		return Result{}, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
 	}
 
 	// Reuse an existing set only if it was built from exactly these files.
 	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath, setInputNames(inputs, folderDir)); ok {
-		return existing, nil
+		return Result{Reused: existing}, nil
 	}
 
 	totalSize := uint64(0)
@@ -97,7 +97,7 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 	if blockSize < 4 {
 		slog.WarnContext(ctx, "Block size too small for PAR2 set creation, skipping",
 			"setName", setName, "totalSize", totalSize)
-		return nil, nil
+		return Result{}, nil
 	}
 	totalSlices := 0
 	for _, f := range inputs {
@@ -144,12 +144,12 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("parpar stdout pipe: %w", err)
+		return Result{}, fmt.Errorf("parpar stdout pipe: %w", err)
 	}
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("parpar start for set %s: %w", setName, err)
+		return Result{}, fmt.Errorf("parpar start for set %s: %w", setName, err)
 	}
 
 	var stdoutBuf bytes.Buffer
@@ -174,7 +174,7 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 	if err := cmd.Wait(); err != nil {
 		if ctx.Err() != nil {
 			slog.InfoContext(ctx, "Parpar set cancelled", "setName", setName)
-			return nil, ctx.Err()
+			return Result{}, ctx.Err()
 		}
 		combined := strings.TrimSpace(stdoutBuf.String())
 		if s := strings.TrimSpace(stderrBuf.String()); s != "" {
@@ -183,7 +183,7 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 			}
 			combined += s
 		}
-		return nil, fmt.Errorf("parpar failed for set %s: %w\noutput: %s", setName, err, combined)
+		return Result{}, fmt.Errorf("parpar failed for set %s: %w\noutput: %s", setName, err, combined)
 	}
 
 	if pg != nil && b.jobProgress != nil {
@@ -193,12 +193,12 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		b.jobProgress.FinishProgress(progressID)
 	}
 
-	return par2SetOnDisk(ctx, dirPath, setName), nil
+	return Result{Created: par2SetOnDisk(ctx, dirPath, setName)}, nil
 }
 
 // CreateInDirectory creates PAR2 files in the specified output directory using the parpar binary.
-func (b *BinaryExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) ([]string, error) {
-	var all []string
+func (b *BinaryExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) (Result, error) {
+	var res Result
 	for _, file := range files {
 		if filepath.Ext(file.Path) == ".par2" {
 			continue
@@ -208,21 +208,21 @@ func (b *BinaryExecutor) CreateInDirectory(ctx context.Context, files []fileinfo
 		sourceDir := filepath.Dir(file.Path)
 		if sourceDir != dirPath {
 			if existing, ok := checkExistingPar2FilesInPath(ctx, file, sourceDir); ok {
-				all = append(all, existing...)
+				res.Reused = append(res.Reused, existing...)
 				continue
 			}
 		}
 		if existing, ok := checkExistingPar2FilesInPath(ctx, file, dirPath); ok {
-			all = append(all, existing...)
+			res.Reused = append(res.Reused, existing...)
 			continue
 		}
 		paths, err := b.runParpar(ctx, file, dirPath)
 		if err != nil {
-			return nil, err
+			return Result{}, err
 		}
-		all = append(all, paths...)
+		res.Created = append(res.Created, paths...)
 	}
-	return all, nil
+	return res, nil
 }
 
 func (b *BinaryExecutor) resolveDir(file fileinfo.FileInfo, outputDir string) string {

--- a/internal/par2/binary.go
+++ b/internal/par2/binary.go
@@ -67,8 +67,8 @@ func (b *BinaryExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 
 	dirPath := outputDir
 	if dirPath == "" {
-		if b.cfg.TempDir != "" {
-			dirPath = b.cfg.TempDir
+		if workDir := WorkDir(b.cfg); workDir != "" {
+			dirPath = workDir
 		} else {
 			dirPath = filepath.Dir(inputs[0].Path)
 		}
@@ -230,9 +230,9 @@ func (b *BinaryExecutor) resolveDir(file fileinfo.FileInfo, outputDir string) st
 		if err := os.MkdirAll(outputDir, 0755); err == nil {
 			return outputDir
 		}
-	} else if b.cfg.TempDir != "" {
-		if err := os.MkdirAll(b.cfg.TempDir, 0755); err == nil {
-			return b.cfg.TempDir
+	} else if workDir := WorkDir(b.cfg); workDir != "" {
+		if err := os.MkdirAll(workDir, 0755); err == nil {
+			return workDir
 		}
 	}
 	return filepath.Dir(file.Path)

--- a/internal/par2/existing.go
+++ b/internal/par2/existing.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/javi11/par2go"
+	"github.com/kipsilabs/postie/internal/config"
 	"github.com/kipsilabs/postie/pkg/fileinfo"
 )
 
@@ -45,6 +46,20 @@ var (
 	par2Magic        = [8]byte{'P', 'A', 'R', '2', 0, 'P', 'K', 'T'}
 	par2TypeFileDesc = [16]byte{'P', 'A', 'R', ' ', '2', '.', '0', 0, 'F', 'i', 'l', 'e', 'D', 'e', 's', 'c'}
 )
+
+// WorkSubdir is the directory Postie creates inside par2.temp_dir for the PAR2
+// files it generates. Keeping them out of the temp root lets the sweeper
+// remove orphans without touching anything that is not Postie's.
+const WorkSubdir = "postie-par2"
+
+// WorkDir returns where generated PAR2 files go when temp_dir is configured,
+// or "" when they are written next to the source files.
+func WorkDir(cfg *config.Par2Config) string {
+	if cfg == nil || cfg.TempDir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.TempDir, WorkSubdir)
+}
 
 // Result is the outcome of a PAR2 request. Created lists the files this call
 // wrote, which Postie owns and may delete once they are no longer needed.

--- a/internal/par2/existing.go
+++ b/internal/par2/existing.go
@@ -1,0 +1,212 @@
+package par2
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/javi11/par2go"
+	"github.com/kipsilabs/postie/pkg/fileinfo"
+)
+
+// volumeSuffixRe matches the part of a PAR2 volume name that follows the set's
+// base name, e.g. ".vol00+01.par2". Anchored on both ends so a set whose name
+// merely starts with ours ("movie.mkv.1080p.vol00+01.par2") never matches.
+var volumeSuffixRe = regexp.MustCompile(`^\.vol\d+\+\d+\.par2$`)
+
+// PAR2 packet layout (all little-endian):
+//
+//	[8]  magic "PAR2\x00PKT"
+//	[8]  packet length, header included
+//	[16] packet MD5
+//	[16] recovery set id
+//	[16] packet type
+//	[..] body
+const (
+	par2HeaderSize     = 64
+	par2FileDescMinLen = 16 + 16 + 16 + 8 // fileID, hashFull, hash16k, length
+	// maxPar2PacketLen bounds a single packet while scanning the main file so a
+	// corrupt length cannot make us allocate or seek absurdly.
+	maxPar2PacketLen = 1 << 30
+	hash16kLen       = 16384
+)
+
+var (
+	par2Magic        = [8]byte{'P', 'A', 'R', '2', 0, 'P', 'K', 'T'}
+	par2TypeFileDesc = [16]byte{'P', 'A', 'R', ' ', '2', '.', '0', 0, 'F', 'i', 'l', 'e', 'D', 'e', 's', 'c'}
+)
+
+// fileDesc is the identity a PAR2 File Description packet records for one
+// input file: its name inside the set, its length and the MD5 of its first
+// 16 KiB. Together they say which bytes the set can repair.
+type fileDesc struct {
+	name    string
+	size    uint64
+	hash16k [16]byte
+}
+
+// par2SetOnDisk returns the main PAR2 file plus every volume belonging to the
+// set named base in dirPath. Only "<base>.par2" and "<base>.volN+M.par2" are
+// accepted; nothing else that merely shares the prefix.
+func par2SetOnDisk(ctx context.Context, dirPath, base string) []string {
+	main := filepath.Join(dirPath, base+".par2")
+	out := []string{main}
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to read directory for par2 volumes", "dir", dirPath, "error", err)
+		return out
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		suffix, ok := strings.CutPrefix(name, base)
+		if !ok || !volumeSuffixRe.MatchString(suffix) {
+			continue
+		}
+		out = append(out, filepath.Join(dirPath, name))
+	}
+	return out
+}
+
+// readFileDescs parses the File Description packets of the PAR2 file at path.
+// The main .par2 file carries no recovery data, so this reads only metadata.
+func readFileDescs(path string) ([]fileDesc, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var descs []fileDesc
+	var header [par2HeaderSize]byte
+	for {
+		if _, err := io.ReadFull(f, header[:]); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("par2 %s: read packet header: %w", path, err)
+		}
+		if !bytes.Equal(header[:8], par2Magic[:]) {
+			return nil, fmt.Errorf("par2 %s: bad packet magic", path)
+		}
+		length := binary.LittleEndian.Uint64(header[8:16])
+		if length < par2HeaderSize || length > maxPar2PacketLen {
+			return nil, fmt.Errorf("par2 %s: implausible packet length %d", path, length)
+		}
+		bodyLen := int64(length - par2HeaderSize)
+
+		if !bytes.Equal(header[48:64], par2TypeFileDesc[:]) {
+			if _, err := f.Seek(bodyLen, io.SeekCurrent); err != nil {
+				return nil, fmt.Errorf("par2 %s: skip packet: %w", path, err)
+			}
+			continue
+		}
+		if bodyLen < par2FileDescMinLen {
+			return nil, fmt.Errorf("par2 %s: FileDesc packet too short (%d bytes)", path, bodyLen)
+		}
+		body := make([]byte, bodyLen)
+		if _, err := io.ReadFull(f, body); err != nil {
+			return nil, fmt.Errorf("par2 %s: read FileDesc: %w", path, err)
+		}
+		var d fileDesc
+		copy(d.hash16k[:], body[32:48])
+		d.size = binary.LittleEndian.Uint64(body[48:56])
+		d.name = string(bytes.TrimRight(body[56:], "\x00"))
+		descs = append(descs, d)
+	}
+	if len(descs) == 0 {
+		return nil, fmt.Errorf("par2 %s: no FileDesc packets", path)
+	}
+	return descs, nil
+}
+
+// describeSource computes the fileDesc a PAR2 creator would record for the
+// file at path under the given in-set name (mirrors par2go's quick scan: MD5
+// of the first 16 KiB, or of the whole file when shorter).
+func describeSource(path, name string) (fileDesc, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return fileDesc{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	st, err := f.Stat()
+	if err != nil {
+		return fileDesc{}, err
+	}
+	d := fileDesc{name: name, size: uint64(st.Size())}
+	if st.Size() == 0 {
+		return d, nil
+	}
+	buf := make([]byte, min(st.Size(), hash16kLen))
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return fileDesc{}, fmt.Errorf("read first 16k of %s: %w", path, err)
+	}
+	d.hash16k = md5.Sum(buf)
+	return d, nil
+}
+
+// par2Describes reports whether the PAR2 set whose main file is mainPath was
+// built from exactly inputs: every input must appear with the same name, size
+// and leading hash, and the set must not describe anything else. A set found
+// on disk that fails this test belongs to other data (an earlier upload with
+// the same name, a changed file, a folder that gained or lost files) and must
+// not be attached to this upload.
+func par2Describes(ctx context.Context, mainPath string, inputs []par2go.InputFile) bool {
+	descs, err := readFileDescs(mainPath)
+	if err != nil {
+		slog.WarnContext(ctx, "Ignoring unreadable PAR2 file", "path", mainPath, "error", err)
+		return false
+	}
+	if len(descs) != len(inputs) {
+		slog.WarnContext(ctx, "Ignoring PAR2 set that describes a different number of files",
+			"path", mainPath, "par2Files", len(descs), "inputFiles", len(inputs))
+		return false
+	}
+
+	byName := make(map[string]fileDesc, len(descs))
+	for _, d := range descs {
+		byName[d.name] = d
+	}
+	for _, in := range inputs {
+		want, err := describeSource(in.Path, in.Name)
+		if err != nil {
+			slog.WarnContext(ctx, "Cannot fingerprint source file for PAR2 reuse", "path", in.Path, "error", err)
+			return false
+		}
+		if got, ok := byName[in.Name]; !ok || got != want {
+			slog.WarnContext(ctx, "Ignoring PAR2 set that does not describe the source file",
+				"path", mainPath, "sourceFile", in.Path)
+			return false
+		}
+	}
+	return true
+}
+
+// setInputNames maps the files of a folder set to the names recorded in its
+// FileDesc packets: the path relative to folderDir with forward slashes (the
+// job folder a downloader creates is already named after the NZB, so the
+// top-level folder name is not part of it). Falls back to the base name.
+func setInputNames(inputs []fileinfo.FileInfo, folderDir string) []par2go.InputFile {
+	out := make([]par2go.InputFile, len(inputs))
+	for i, f := range inputs {
+		name, err := filepath.Rel(folderDir, f.Path)
+		if err != nil || name == "" || name == "." {
+			name = filepath.Base(f.Path)
+		}
+		out[i] = par2go.InputFile{Path: f.Path, Name: filepath.ToSlash(name)}
+	}
+	return out
+}

--- a/internal/par2/existing.go
+++ b/internal/par2/existing.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/javi11/par2go"
@@ -44,6 +45,21 @@ var (
 	par2Magic        = [8]byte{'P', 'A', 'R', '2', 0, 'P', 'K', 'T'}
 	par2TypeFileDesc = [16]byte{'P', 'A', 'R', ' ', '2', '.', '0', 0, 'F', 'i', 'l', 'e', 'D', 'e', 's', 'c'}
 )
+
+// Result is the outcome of a PAR2 request. Created lists the files this call
+// wrote, which Postie owns and may delete once they are no longer needed.
+// Reused lists PAR2 files that already existed on disk (the user's own, or a
+// verified leftover from an earlier run); they are posted alongside the
+// sources but are never Postie's to delete.
+type Result struct {
+	Created []string
+	Reused  []string
+}
+
+// All returns every PAR2 file to post, reused first.
+func (r Result) All() []string {
+	return slices.Concat(r.Reused, r.Created)
+}
 
 // fileDesc is the identity a PAR2 File Description packet records for one
 // input file: its name inside the set, its length and the MD5 of its first

--- a/internal/par2/existing_test.go
+++ b/internal/par2/existing_test.go
@@ -1,0 +1,181 @@
+package par2
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/javi11/par2go"
+	"github.com/kipsilabs/postie/internal/config"
+	"github.com/kipsilabs/postie/pkg/fileinfo"
+)
+
+// writeRealPar2Files generates a genuine PAR2 set for sourcePath into dir using
+// par2go, so the FileDesc packets describe sourcePath. With NumRecovery=1 the
+// volume is named "<base>.vol00+01.par2". Returns the main file path.
+func writeRealPar2Files(t *testing.T, dir, sourcePath string, numRecovery int) string {
+	t.Helper()
+	main := filepath.Join(dir, filepath.Base(sourcePath)+".par2")
+	opts := par2go.Options{SliceSize: 4096, NumRecovery: numRecovery, NumGoroutines: 1, Creator: "test"}
+	if err := par2go.Create(context.Background(), main, []string{sourcePath}, opts); err != nil {
+		t.Fatalf("writeRealPar2Files: %v", err)
+	}
+	return main
+}
+
+// writeRealPar2Set generates a genuine PAR2 set named setName for inputs.
+func writeRealPar2Set(t *testing.T, dir, setName string, inputs []par2go.InputFile) string {
+	t.Helper()
+	main := filepath.Join(dir, setName+".par2")
+	opts := par2go.Options{SliceSize: 4096, NumRecovery: 1, NumGoroutines: 1, Creator: "test"}
+	if err := par2go.CreateWithNames(context.Background(), main, inputs, opts); err != nil {
+		t.Fatalf("writeRealPar2Set: %v", err)
+	}
+	return main
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Regression for kipsilabs/postie#184 (last comment): volumes were collected
+// with a loose prefix match, so any "<base>*.vol*.par2" file in a shared temp
+// dir (e.g. from a different upload whose name starts with this one) was
+// pulled into the NZB.
+func TestPar2SetOnDisk_StrictNameMatching(t *testing.T) {
+	dir := t.TempDir()
+	want := []string{"movie.mkv.par2", "movie.mkv.vol00+01.par2", "movie.mkv.vol01+02.par2", "movie.mkv.vol123+456.par2"}
+	decoys := []string{
+		"movie.mkv.1080p.vol00+01.par2", // other upload sharing the prefix
+		"movie.mkv.PROPER.par2",
+		"movie.mkv.volatile.par2",
+		"movie.mkvx.vol00+01.par2",
+		"movie.mkv.vol00+01.par2.tmp",
+		"movie.mkv.vol.par2",
+		"other.mkv.vol00+01.par2",
+	}
+	for _, n := range slices.Concat(want, decoys) {
+		touch(t, filepath.Join(dir, n))
+	}
+	if err := os.Mkdir(filepath.Join(dir, "movie.mkv.vol02+03.par2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := par2SetOnDisk(context.Background(), dir, "movie.mkv")
+	var names []string
+	for _, p := range got {
+		names = append(names, filepath.Base(p))
+	}
+	slices.Sort(names)
+	slices.Sort(want)
+	if !slices.Equal(names, want) {
+		t.Fatalf("par2SetOnDisk = %v, want %v", names, want)
+	}
+}
+
+func TestReadFileDescs_MatchesSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "data.bin")
+	createTestFile(t, src, 50000)
+	main := writeRealPar2Files(t, dir, src, 1)
+
+	descs, err := readFileDescs(main)
+	if err != nil {
+		t.Fatalf("readFileDescs: %v", err)
+	}
+	if len(descs) != 1 {
+		t.Fatalf("expected 1 FileDesc, got %d", len(descs))
+	}
+	want, err := describeSource(src, "data.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if descs[0] != want {
+		t.Fatalf("FileDesc = %+v, want %+v", descs[0], want)
+	}
+}
+
+func TestReadFileDescs_RejectsGarbage(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.par2")
+	touch(t, p)
+	if _, err := readFileDescs(p); err == nil {
+		t.Fatal("expected error for non-PAR2 content")
+	}
+}
+
+// Regression for kipsilabs/postie#184 (last comment): a PAR2 set left behind in
+// the shared temp dir by an earlier upload (the transfer rows were dropped, so
+// the cleaner never removed it) was reused for any later file with the same
+// basename, even though it described different content.
+func TestCheckExistingPar2Files_RejectsPar2ForDifferentContent(t *testing.T) {
+	ctx := context.Background()
+	sourceDir := t.TempDir()
+	tempDir := t.TempDir()
+	staleDir := t.TempDir()
+
+	// Stale set: same basename and size, different bytes.
+	stale := filepath.Join(staleDir, "archive.rar")
+	if err := os.WriteFile(stale, make([]byte, 50000), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeRealPar2Files(t, tempDir, stale, 1)
+
+	src := filepath.Join(sourceDir, "archive.rar")
+	createTestFile(t, src, 50000)
+
+	exec := New(10000, &config.Par2Config{Redundancy: "10", TempDir: tempDir}, nil)
+	file := fileinfo.FileInfo{Path: src, Size: 50000}
+
+	if paths, ok := exec.checkExistingPar2Files(ctx, file); ok {
+		t.Fatalf("stale PAR2 for different content must not be reused, got %v", paths)
+	}
+
+	// A set that really describes the source is reused.
+	writeRealPar2Files(t, tempDir, src, 1)
+	paths, ok := exec.checkExistingPar2Files(ctx, file)
+	if !ok || len(paths) != 2 {
+		t.Fatalf("matching PAR2 should be reused, ok=%v paths=%v", ok, paths)
+	}
+}
+
+func TestCheckExistingPar2Set_RejectsStaleSet(t *testing.T) {
+	ctx := context.Background()
+	folder := t.TempDir()
+	tempDir := t.TempDir()
+
+	a := filepath.Join(folder, "a.bin")
+	b := filepath.Join(folder, "b.bin")
+	createTestFile(t, a, 20000)
+	createTestFile(t, b, 30000)
+	inputs := []par2go.InputFile{{Path: a, Name: "a.bin"}, {Path: b, Name: "b.bin"}}
+	writeRealPar2Set(t, tempDir, "folder", inputs)
+
+	if paths, ok := checkExistingPar2SetInPath(ctx, "folder", tempDir, inputs); !ok || len(paths) != 2 {
+		t.Fatalf("matching set should be reused, ok=%v paths=%v", ok, paths)
+	}
+
+	// Folder gained a file: the old set no longer covers it.
+	c := filepath.Join(folder, "c.bin")
+	createTestFile(t, c, 10000)
+	grown := append(slices.Clone(inputs), par2go.InputFile{Path: c, Name: "c.bin"})
+	if paths, ok := checkExistingPar2SetInPath(ctx, "folder", tempDir, grown); ok {
+		t.Fatalf("set missing a file must not be reused, got %v", paths)
+	}
+
+	// Folder lost a file: the old set describes something that is not posted.
+	if paths, ok := checkExistingPar2SetInPath(ctx, "folder", tempDir, inputs[:1]); ok {
+		t.Fatalf("set with extra files must not be reused, got %v", paths)
+	}
+
+	// Same names, different content.
+	createTestFile(t, a, 20001)
+	if paths, ok := checkExistingPar2SetInPath(ctx, "folder", tempDir, inputs); ok {
+		t.Fatalf("set for changed content must not be reused, got %v", paths)
+	}
+}

--- a/internal/par2/existing_test.go
+++ b/internal/par2/existing_test.go
@@ -179,3 +179,36 @@ func TestCheckExistingPar2Set_RejectsStaleSet(t *testing.T) {
 		t.Fatalf("set for changed content must not be reused, got %v", paths)
 	}
 }
+
+// Callers must be able to tell PAR2 files Postie wrote (which it may delete
+// later) from pre-existing ones it merely reused (kipsilabs/postie#274).
+func TestResult_DistinguishesReusedFromCreated(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "video.mkv")
+	createTestFile(t, src, 50000)
+	exec := New(10000, &config.Par2Config{Redundancy: "10"}, nil)
+	files := []fileinfo.FileInfo{{Path: src, Size: 50000}}
+
+	res, err := exec.CreateInDirectory(ctx, files, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Created) == 0 || len(res.Reused) != 0 {
+		t.Fatalf("fresh generation: Created=%v Reused=%v", res.Created, res.Reused)
+	}
+
+	res, err = exec.CreateInDirectory(ctx, files, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Reused) == 0 || len(res.Created) != 0 {
+		t.Fatalf("second run must reuse: Created=%v Reused=%v", res.Created, res.Reused)
+	}
+	if got := res.All(); len(got) != len(res.Reused) {
+		t.Fatalf("All() = %v", got)
+	}
+}
+
+// all flattens a Result for tests that only care about the posted paths.
+func all(r Result, err error) ([]string, error) { return r.All(), err }

--- a/internal/par2/existing_test.go
+++ b/internal/par2/existing_test.go
@@ -124,7 +124,11 @@ func TestCheckExistingPar2Files_RejectsPar2ForDifferentContent(t *testing.T) {
 	if err := os.WriteFile(stale, make([]byte, 50000), 0644); err != nil {
 		t.Fatal(err)
 	}
-	writeRealPar2Files(t, tempDir, stale, 1)
+	workDir := filepath.Join(tempDir, WorkSubdir)
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeRealPar2Files(t, workDir, stale, 1)
 
 	src := filepath.Join(sourceDir, "archive.rar")
 	createTestFile(t, src, 50000)
@@ -137,7 +141,7 @@ func TestCheckExistingPar2Files_RejectsPar2ForDifferentContent(t *testing.T) {
 	}
 
 	// A set that really describes the source is reused.
-	writeRealPar2Files(t, tempDir, src, 1)
+	writeRealPar2Files(t, workDir, src, 1)
 	paths, ok := exec.checkExistingPar2Files(ctx, file)
 	if !ok || len(paths) != 2 {
 		t.Fatalf("matching PAR2 should be reused, ok=%v paths=%v", ok, paths)
@@ -212,3 +216,18 @@ func TestResult_DistinguishesReusedFromCreated(t *testing.T) {
 
 // all flattens a Result for tests that only care about the posted paths.
 func all(r Result, err error) ([]string, error) { return r.All(), err }
+
+// Generated PAR2 files live in a Postie-owned subdirectory of temp_dir so the
+// sweeper can safely remove orphans without touching anything else.
+func TestWorkDir(t *testing.T) {
+	if got := WorkDir(&config.Par2Config{}); got != "" {
+		t.Errorf("empty temp_dir: WorkDir = %q, want empty (PAR2 next to sources)", got)
+	}
+	if got := WorkDir(nil); got != "" {
+		t.Errorf("nil cfg: WorkDir = %q", got)
+	}
+	want := filepath.Join("/tmp", WorkSubdir)
+	if got := WorkDir(&config.Par2Config{TempDir: "/tmp"}); got != want {
+		t.Errorf("WorkDir = %q, want %q", got, want)
+	}
+}

--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -28,14 +28,14 @@ const maxPar2Blocks = 32768
 
 // Par2Executor defines the interface for executing par2 commands.
 type Par2Executor interface {
-	Create(ctx context.Context, files []fileinfo.FileInfo) ([]string, error)
-	CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) ([]string, error)
+	Create(ctx context.Context, files []fileinfo.FileInfo) (Result, error)
+	CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) (Result, error)
 	// CreateSet bundles all input files into a single par2 set named setName.
 	// folderDir is the on-disk root of the folder being posted (e.g.
 	// "<watchRoot>/ShowS01"). Each FileDesc packet records the path of the
 	// file relative to folderDir (e.g. "extras/bonus.mkv") so downloaders
 	// such as SABnzbd can recreate the folder tree inside the job directory.
-	CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) ([]string, error)
+	CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) (Result, error)
 }
 
 var gf16Methods = map[string]int{
@@ -121,10 +121,10 @@ func checkExistingPar2FilesInPath(ctx context.Context, sourceFile fileinfo.FileI
 }
 
 // Create creates PAR2 parity files for the given input files.
-func (p *NativeExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) ([]string, error) {
+func (p *NativeExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) (Result, error) {
 	slog.InfoContext(ctx, "Starting par2 creation process", "executor", "NativeExecutor")
 
-	var createdPar2Paths []string
+	var res Result
 	for _, file := range files {
 		if filepath.Ext(file.Path) == ".par2" {
 			continue
@@ -132,7 +132,7 @@ func (p *NativeExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) 
 
 		// Check if PAR2 files already exist for this file
 		if existingPaths, exists := p.checkExistingPar2Files(ctx, file); exists {
-			createdPar2Paths = append(createdPar2Paths, existingPaths...)
+			res.Reused = append(res.Reused, existingPaths...)
 			continue
 		}
 
@@ -150,19 +150,19 @@ func (p *NativeExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) 
 
 		paths, err := p.createPar2ForFile(ctx, file, dirPath)
 		if err != nil {
-			return nil, err
+			return Result{}, err
 		}
-		createdPar2Paths = append(createdPar2Paths, paths...)
+		res.Created = append(res.Created, paths...)
 	}
 
-	return createdPar2Paths, nil
+	return res, nil
 }
 
 // CreateInDirectory creates PAR2 files with optional output directory specification.
-func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) ([]string, error) {
+func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) (Result, error) {
 	slog.InfoContext(ctx, "Starting par2 creation process", "executor", "NativeExecutor", "outputDir", outputDir)
 
-	var createdPar2Paths []string
+	var res Result
 	for _, file := range files {
 		if filepath.Ext(file.Path) == ".par2" {
 			continue
@@ -178,11 +178,11 @@ func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo
 			} else {
 				// Check source directory first — pre-existing PAR2 files take priority.
 				if existingPaths, exists := checkExistingPar2FilesInPath(ctx, file, filepath.Dir(file.Path)); exists {
-					createdPar2Paths = append(createdPar2Paths, existingPaths...)
+					res.Reused = append(res.Reused, existingPaths...)
 					continue
 				}
 				if existingPaths, exists := p.checkExistingPar2FilesInDir(ctx, file, dirPath); exists {
-					createdPar2Paths = append(createdPar2Paths, existingPaths...)
+					res.Reused = append(res.Reused, existingPaths...)
 					continue
 				}
 			}
@@ -193,42 +193,42 @@ func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo
 				dirPath = filepath.Dir(file.Path)
 			} else {
 				if existingPaths, exists := p.checkExistingPar2Files(ctx, file); exists {
-					createdPar2Paths = append(createdPar2Paths, existingPaths...)
+					res.Reused = append(res.Reused, existingPaths...)
 					continue
 				}
 			}
 		} else {
 			dirPath = filepath.Dir(file.Path)
 			if existingPaths, exists := p.checkExistingPar2Files(ctx, file); exists {
-				createdPar2Paths = append(createdPar2Paths, existingPaths...)
+				res.Reused = append(res.Reused, existingPaths...)
 				continue
 			}
 		}
 
 		paths, err := p.createPar2ForFile(ctx, file, dirPath)
 		if err != nil {
-			return nil, err
+			return Result{}, err
 		}
-		createdPar2Paths = append(createdPar2Paths, paths...)
+		res.Created = append(res.Created, paths...)
 	}
 
-	return createdPar2Paths, nil
+	return res, nil
 }
 
 // CreateSet bundles all input files into a single par2 set named setName.
 // folderDir is the on-disk root of the folder being posted.  Each FileDesc
 // packet records filepath.Rel(folderDir, file.Path) so SABnzbd / NZBGet
 // can recreate the exact folder tree inside the job directory on disk.
-func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) ([]string, error) {
+func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) (Result, error) {
 	if len(files) == 0 {
-		return nil, fmt.Errorf("par2: no input files for set %q", setName)
+		return Result{}, fmt.Errorf("par2: no input files for set %q", setName)
 	}
 	if setName == "" {
-		return nil, fmt.Errorf("par2: empty set name")
+		return Result{}, fmt.Errorf("par2: empty set name")
 	}
 	gf16Method, err := gf16MethodFromConfig(p.cfg.GF16Method)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 
 	// Filter out any par2 files defensively — callers should not include them.
@@ -240,7 +240,7 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		inputs = append(inputs, f)
 	}
 	if len(inputs) == 0 {
-		return nil, fmt.Errorf("par2: no non-par2 input files for set %q", setName)
+		return Result{}, fmt.Errorf("par2: no non-par2 input files for set %q", setName)
 	}
 
 	dirPath := outputDir
@@ -252,14 +252,14 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		}
 	}
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		return nil, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
+		return Result{}, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
 	}
 
 	par2Inputs := setInputNames(inputs, folderDir)
 
 	// Reuse an existing set only if it was built from exactly these files.
 	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath, par2Inputs); ok {
-		return existing, nil
+		return Result{Reused: existing}, nil
 	}
 
 	// Slice size: smallest size that yields ≤ maxPar2Blocks slices across all
@@ -276,7 +276,7 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 	if parBlockSize < 128 {
 		slog.WarnContext(ctx, "Block size too small for SIMD-safe PAR2 set creation, skipping",
 			"setName", setName, "totalSize", totalSize, "blockSize", parBlockSize)
-		return nil, nil
+		return Result{}, nil
 	}
 
 	// Total input slices and recovery blocks
@@ -339,16 +339,16 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 	if err := par2go.CreateWithNames(ctx, par2Path, par2Inputs, opts); err != nil {
 		if ctx.Err() == context.Canceled {
 			slog.InfoContext(ctx, "Par2 set creation cancelled", "setName", setName)
-			return nil, ctx.Err()
+			return Result{}, ctx.Err()
 		}
-		return nil, fmt.Errorf("failed to create par2 set %s: %w", setName, err)
+		return Result{}, fmt.Errorf("failed to create par2 set %s: %w", setName, err)
 	}
 
 	if p.jobProgress != nil {
 		p.jobProgress.FinishProgress(progressID)
 	}
 
-	return par2SetOnDisk(ctx, dirPath, setName), nil
+	return Result{Created: par2SetOnDisk(ctx, dirPath, setName)}, nil
 }
 
 // computeSetBlockSize picks a slice size for a multi-file par2 set such that

--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -100,40 +100,23 @@ func (p *NativeExecutor) checkExistingPar2FilesInDir(ctx context.Context, source
 }
 
 // checkExistingPar2FilesInPath is the shared implementation for checking existing PAR2 files.
+// A set is only reused when its main file describes exactly this source file
+// (name, size and leading hash); anything else on disk under the same name is a
+// leftover from other data and is ignored.
 func checkExistingPar2FilesInPath(ctx context.Context, sourceFile fileinfo.FileInfo, dirPath string) ([]string, bool) {
 	baseName := filepath.Base(sourceFile.Path)
-	par2FileName := baseName + ".par2"
-	mainPar2Path := filepath.Join(dirPath, par2FileName)
+	mainPar2Path := filepath.Join(dirPath, baseName+".par2")
 
-	// Check if main PAR2 file exists
 	if _, err := os.Stat(mainPar2Path); os.IsNotExist(err) {
 		return nil, false
 	}
-
-	// Collect all existing PAR2 files (main + volume files)
-	var existingPaths []string
-	existingPaths = append(existingPaths, mainPar2Path)
-
-	// Find all volume files
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to read directory for existing par2 volumes", "error", err)
+	if !par2Describes(ctx, mainPar2Path, []par2go.InputFile{{Path: sourceFile.Path, Name: baseName}}) {
 		return nil, false
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasPrefix(name, baseName) && strings.Contains(name, ".vol") && strings.HasSuffix(name, ".par2") {
-			existingPaths = append(existingPaths, filepath.Join(dirPath, name))
-		}
-	}
-
+	existingPaths := par2SetOnDisk(ctx, dirPath, baseName)
 	slog.InfoContext(ctx, "Found existing PAR2 files, skipping generation",
 		"sourceFile", sourceFile.Path, "par2Files", len(existingPaths))
-
 	return existingPaths, true
 }
 
@@ -272,8 +255,10 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		return nil, fmt.Errorf("par2: create output dir %s: %w", dirPath, err)
 	}
 
-	// Reuse existing set if already on disk.
-	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath); ok {
+	par2Inputs := setInputNames(inputs, folderDir)
+
+	// Reuse an existing set only if it was built from exactly these files.
+	if existing, ok := checkExistingPar2SetInPath(ctx, setName, dirPath, par2Inputs); ok {
 		return existing, nil
 	}
 
@@ -313,20 +298,6 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 	var pg progress.Progress
 	if p.jobProgress != nil {
 		pg = p.jobProgress.AddProgress(progressID, progressName, progress.ProgressTypePar2Generation, 100)
-	}
-
-	par2Inputs := make([]par2go.InputFile, len(inputs))
-	for i, f := range inputs {
-		// Compute the path relative to folderDir (e.g. "extras/bonus.mkv").
-		// SABnzbd already creates a job folder named after the NZB title, so
-		// FileDesc must NOT include the top-level folder name as a prefix.
-		name, relErr := filepath.Rel(folderDir, f.Path)
-		if relErr != nil || name == "" || name == "." {
-			name = filepath.Base(f.Path)
-		}
-		// Forward slashes only — par2go validates this and downloaders rely on it.
-		name = filepath.ToSlash(name)
-		par2Inputs[i] = par2go.InputFile{Path: f.Path, Name: name}
 	}
 
 	opts := par2go.Options{
@@ -377,7 +348,7 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 		p.jobProgress.FinishProgress(progressID)
 	}
 
-	return collectPar2SetFiles(ctx, dirPath, setName, par2Path), nil
+	return par2SetOnDisk(ctx, dirPath, setName), nil
 }
 
 // computeSetBlockSize picks a slice size for a multi-file par2 set such that
@@ -413,37 +384,19 @@ func (p *NativeExecutor) computeSetBlockSize(totalSize, maxFileSize uint64) uint
 }
 
 // checkExistingPar2SetInPath looks for an already-generated par2 set in
-// dirPath named "<setName>.par2" plus any companion volume files.
-func checkExistingPar2SetInPath(ctx context.Context, setName, dirPath string) ([]string, bool) {
+// dirPath and reuses it only when it describes exactly inputs.
+func checkExistingPar2SetInPath(ctx context.Context, setName, dirPath string, inputs []par2go.InputFile) ([]string, bool) {
 	main := filepath.Join(dirPath, setName+".par2")
 	if _, err := os.Stat(main); os.IsNotExist(err) {
 		return nil, false
 	}
-	paths := collectPar2SetFiles(ctx, dirPath, setName, main)
+	if !par2Describes(ctx, main, inputs) {
+		return nil, false
+	}
+	paths := par2SetOnDisk(ctx, dirPath, setName)
 	slog.InfoContext(ctx, "Found existing PAR2 set, skipping generation",
 		"setName", setName, "par2Files", len(paths))
 	return paths, true
-}
-
-// collectPar2SetFiles returns the main par2 path plus all companion volume
-// files matching "<setName>.vol*.par2" in dirPath.
-func collectPar2SetFiles(ctx context.Context, dirPath, setName, mainPath string) []string {
-	out := []string{mainPath}
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to read directory for par2 volumes", "error", err)
-		return out
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasPrefix(name, setName) && strings.Contains(name, ".vol") && strings.HasSuffix(name, ".par2") {
-			out = append(out, filepath.Join(dirPath, name))
-		}
-	}
-	return out
 }
 
 // computeFileBlockSize picks a SIMD-safe slice size for a single file. Returns
@@ -564,27 +517,7 @@ func (p *NativeExecutor) createPar2ForFile(ctx context.Context, file fileinfo.Fi
 	slog.InfoContext(ctx, "Par2 creation completed successfully", "file", file.Path)
 
 	// Collect all created PAR2 files (main + volumes)
-	var createdPaths []string
-	createdPaths = append(createdPaths, par2Path)
-
-	baseName := filepath.Base(file.Path)
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		slog.WarnContext(ctx, "Failed to read directory to find par2 volumes", "error", err)
-		return createdPaths, nil
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasPrefix(name, baseName) && strings.Contains(name, ".vol") && strings.HasSuffix(name, ".par2") {
-			createdPaths = append(createdPaths, filepath.Join(dirPath, name))
-		}
-	}
-
-	return createdPaths, nil
+	return par2SetOnDisk(ctx, dirPath, filepath.Base(file.Path)), nil
 }
 
 // parseRedundancyPercentage parses the redundancy config string into a percentage.

--- a/internal/par2/par2.go
+++ b/internal/par2/par2.go
@@ -78,7 +78,7 @@ func New(articleSize uint64, cfg *config.Par2Config, jobProgress progress.JobPro
 }
 
 // checkExistingPar2Files checks if PAR2 files already exist for the given source file.
-// It always checks the source directory first, then falls back to TempDir if configured.
+// It always checks the source directory first, then falls back to the work dir if configured.
 func (p *NativeExecutor) checkExistingPar2Files(ctx context.Context, sourceFile fileinfo.FileInfo) ([]string, bool) {
 	// Always check the source directory first — this is where pre-existing PAR2 files live.
 	sourceDirPath := filepath.Dir(sourceFile.Path)
@@ -86,9 +86,9 @@ func (p *NativeExecutor) checkExistingPar2Files(ctx context.Context, sourceFile 
 		return existing, ok
 	}
 
-	// Fall back to TempDir if configured (reuse from a previous generation run).
-	if p.cfg.TempDir != "" && p.cfg.TempDir != sourceDirPath {
-		return checkExistingPar2FilesInPath(ctx, sourceFile, p.cfg.TempDir)
+	// Fall back to the work dir if configured (reuse from a previous generation run).
+	if workDir := WorkDir(p.cfg); workDir != "" && workDir != sourceDirPath {
+		return checkExistingPar2FilesInPath(ctx, sourceFile, workDir)
 	}
 
 	return nil, false
@@ -138,8 +138,8 @@ func (p *NativeExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) 
 
 		// Determine output directory
 		var dirPath string
-		if p.cfg.TempDir != "" {
-			dirPath = p.cfg.TempDir
+		if workDir := WorkDir(p.cfg); workDir != "" {
+			dirPath = workDir
 			if err := os.MkdirAll(dirPath, 0755); err != nil {
 				slog.ErrorContext(ctx, "Failed to create temp directory", "path", dirPath, "error", err)
 				dirPath = filepath.Dir(file.Path)
@@ -186,16 +186,17 @@ func (p *NativeExecutor) CreateInDirectory(ctx context.Context, files []fileinfo
 					continue
 				}
 			}
-		} else if p.cfg.TempDir != "" {
-			dirPath = p.cfg.TempDir
+		} else if workDir := WorkDir(p.cfg); workDir != "" {
+			// Look for a reusable set before creating the work dir, so a job that
+			// reuses source-dir PAR2 files leaves the temp dir untouched.
+			if existingPaths, exists := p.checkExistingPar2Files(ctx, file); exists {
+				res.Reused = append(res.Reused, existingPaths...)
+				continue
+			}
+			dirPath = workDir
 			if err := os.MkdirAll(dirPath, 0755); err != nil {
 				slog.ErrorContext(ctx, "Failed to create temp directory", "path", dirPath, "error", err)
 				dirPath = filepath.Dir(file.Path)
-			} else {
-				if existingPaths, exists := p.checkExistingPar2Files(ctx, file); exists {
-					res.Reused = append(res.Reused, existingPaths...)
-					continue
-				}
 			}
 		} else {
 			dirPath = filepath.Dir(file.Path)
@@ -245,8 +246,8 @@ func (p *NativeExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInf
 
 	dirPath := outputDir
 	if dirPath == "" {
-		if p.cfg.TempDir != "" {
-			dirPath = p.cfg.TempDir
+		if workDir := WorkDir(p.cfg); workDir != "" {
+			dirPath = workDir
 		} else {
 			dirPath = filepath.Dir(inputs[0].Path)
 		}

--- a/internal/par2/par2_integration_test.go
+++ b/internal/par2/par2_integration_test.go
@@ -95,10 +95,14 @@ func TestIntegration_NativeExecutor_SkipsWhenPar2FilesExistInSourceDir(t *testin
 	executor := New(750_000, cfg, nil)
 
 	files := []fileinfo.FileInfo{{Path: sourcePath, Size: 1024 * 1024}}
-	result, err := executor.Create(context.Background(), files)
+	res, err := executor.Create(context.Background(), files)
 	if err != nil {
 		t.Fatalf("Create: unexpected error: %v", err)
 	}
+	if len(res.Created) != 0 || len(res.Reused) == 0 {
+		t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+	}
+	result := res.All()
 
 	// Must return at least the two pre-existing files.
 	if len(result) < 2 {
@@ -154,10 +158,14 @@ func TestIntegration_NativeExecutor_SkipsWhenPar2FilesExistInTempDir(t *testing.
 	executor := New(750_000, cfg, nil)
 
 	files := []fileinfo.FileInfo{{Path: sourcePath, Size: 512 * 1024}}
-	result, err := executor.Create(context.Background(), files)
+	res, err := executor.Create(context.Background(), files)
 	if err != nil {
 		t.Fatalf("Create: unexpected error: %v", err)
 	}
+	if len(res.Created) != 0 || len(res.Reused) == 0 {
+		t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+	}
+	result := res.All()
 
 	if len(result) == 0 {
 		t.Fatal("expected PAR2 paths to be returned (from TempDir), got empty result")
@@ -193,7 +201,7 @@ func TestIntegration_NativeExecutor_RegeneratesWhenNoPar2FilesExist(t *testing.T
 	executor := New(10_000, cfg, nil)
 
 	files := []fileinfo.FileInfo{{Path: sourcePath, Size: 100_000}}
-	result, err := executor.Create(context.Background(), files)
+	result, err := all(executor.Create(context.Background(), files))
 	if err != nil {
 		t.Fatalf("Create: unexpected error: %v", err)
 	}
@@ -226,10 +234,14 @@ func TestIntegration_BinaryExecutor_SkipsWhenPar2FilesExistInSourceDir(t *testin
 	executor := NewBinaryExecutor(750_000, cfg, nil)
 
 	files := []fileinfo.FileInfo{{Path: sourcePath, Size: 2 * 1024 * 1024}}
-	result, err := executor.CreateInDirectory(context.Background(), files, "")
+	res, err := executor.CreateInDirectory(context.Background(), files, "")
 	if err != nil {
 		t.Fatalf("CreateInDirectory: unexpected error: %v", err)
 	}
+	if len(res.Created) != 0 || len(res.Reused) == 0 {
+		t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+	}
+	result := res.All()
 	if len(result) == 0 {
 		t.Fatal("expected existing PAR2 paths returned, got empty result")
 	}
@@ -271,7 +283,7 @@ func TestIntegration_NativeExecutor_HandlesVerySmallFiles_512Bytes(t *testing.T)
 				t.Errorf("executor panicked on 512-byte file: %v", rec)
 			}
 		}()
-		return executor.Create(context.Background(), files)
+		return all(executor.Create(context.Background(), files))
 	}()
 
 	if err != nil {
@@ -303,7 +315,7 @@ func TestIntegration_NativeExecutor_HandlesVerySmallFiles_10Bytes(t *testing.T) 
 				t.Errorf("executor panicked on 10-byte file: %v", rec)
 			}
 		}()
-		return executor.Create(context.Background(), files)
+		return all(executor.Create(context.Background(), files))
 	}()
 
 	// A 10-byte file is too small for a meaningful PAR2 block; expect either
@@ -381,7 +393,7 @@ func TestIntegration_NativeExecutor_SkipsInputPar2Files(t *testing.T) {
 		{Path: par2Path, Size: 500},
 	}
 
-	_, err := executor.Create(context.Background(), files)
+	_, err := all(executor.Create(context.Background(), files))
 	if err != nil {
 		t.Fatalf("Create: unexpected error: %v", err)
 	}
@@ -447,7 +459,7 @@ func TestIntegration_NativeExecutor_CreateSet_EmbedsRelativePaths(t *testing.T) 
 	// folderDir is the on-disk root of the folder being posted.
 	// FileDesc names must be relative to this dir (no top-level prefix).
 	folderDir := pkgDir
-	created, err := executor.CreateSet(context.Background(), files, outDir, "folder1-testpkg", folderDir)
+	created, err := all(executor.CreateSet(context.Background(), files, outDir, "folder1-testpkg", folderDir))
 	if err != nil {
 		t.Fatalf("CreateSet: %v", err)
 	}
@@ -575,7 +587,7 @@ func TestIntegration_NativeExecutor_PinnedLookupKernel(t *testing.T) {
 	executor := New(10_000, cfg, nil)
 
 	files := []fileinfo.FileInfo{{Path: sourcePath, Size: 100_000}}
-	result, err := executor.Create(context.Background(), files)
+	result, err := all(executor.Create(context.Background(), files))
 	if err != nil {
 		t.Fatalf("Create: unexpected error: %v", err)
 	}
@@ -600,7 +612,7 @@ func TestIntegration_NativeExecutor_RejectsUnknownGF16Method(t *testing.T) {
 	}
 	executor := New(10_000, cfg, nil)
 
-	_, err := executor.Create(context.Background(), []fileinfo.FileInfo{{Path: sourcePath, Size: 100_000}})
+	_, err := all(executor.Create(context.Background(), []fileinfo.FileInfo{{Path: sourcePath, Size: 100_000}}))
 	if err == nil {
 		t.Fatal("Create: expected error for gf16_method=bogus, got nil")
 	}

--- a/internal/par2/par2_integration_test.go
+++ b/internal/par2/par2_integration_test.go
@@ -33,16 +33,14 @@ func createIntegrationTestFile(t *testing.T, dir, name string, size int) string 
 	return path
 }
 
-// createFakePar2Files places empty files that look like PAR2 outputs for sourceFile.
-// Returns paths of the created files.
-func createFakePar2Files(t *testing.T, dir, sourceBaseName string) (main string, vol string) {
+// createRealPar2Files generates a genuine one-volume PAR2 set for sourcePath
+// into dir, so its FileDesc describes sourcePath. Returns the created paths.
+func createRealPar2Files(t *testing.T, dir, sourcePath string) (main string, vol string) {
 	t.Helper()
-	main = filepath.Join(dir, sourceBaseName+".par2")
-	vol = filepath.Join(dir, sourceBaseName+".vol0+1.par2")
-	for _, p := range []string{main, vol} {
-		if err := os.WriteFile(p, []byte("fake par2 content"), 0644); err != nil {
-			t.Fatalf("createFakePar2Files: %v", err)
-		}
+	main = writeRealPar2Files(t, dir, sourcePath, 1)
+	vol = filepath.Join(dir, filepath.Base(sourcePath)+".vol00+01.par2")
+	if _, err := os.Stat(vol); err != nil {
+		t.Fatalf("createRealPar2Files: volume missing: %v", err)
 	}
 	return main, vol
 }
@@ -77,7 +75,7 @@ func TestIntegration_NativeExecutor_SkipsWhenPar2FilesExistInSourceDir(t *testin
 	tempDir := t.TempDir()
 
 	sourcePath := createIntegrationTestFile(t, dir, "movie.rar", 1024*1024) // 1 MB
-	mainPar2, volPar2 := createFakePar2Files(t, dir, "movie.rar")
+	mainPar2, volPar2 := createRealPar2Files(t, dir, sourcePath)
 
 	// Record modification times before calling Create.
 	statBefore := func(path string) int64 {
@@ -147,7 +145,7 @@ func TestIntegration_NativeExecutor_SkipsWhenPar2FilesExistInTempDir(t *testing.
 
 	sourcePath := createIntegrationTestFile(t, sourceDir, "archive.rar", 512*1024)
 	// PAR2 files live only in tempDir, not in sourceDir.
-	mainPar2, _ := createFakePar2Files(t, tempDir, "archive.rar")
+	mainPar2, _ := createRealPar2Files(t, tempDir, sourcePath)
 
 	cfg := &config.Par2Config{
 		Redundancy: "10",
@@ -219,7 +217,7 @@ func TestIntegration_NativeExecutor_RegeneratesWhenNoPar2FilesExist(t *testing.T
 func TestIntegration_BinaryExecutor_SkipsWhenPar2FilesExistInSourceDir(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := createIntegrationTestFile(t, dir, "video.mkv", 2*1024*1024)
-	mainPar2, _ := createFakePar2Files(t, dir, "video.mkv")
+	mainPar2, _ := createRealPar2Files(t, dir, sourcePath)
 
 	cfg := &config.Par2Config{
 		Redundancy:       "10",

--- a/internal/par2/par2_integration_test.go
+++ b/internal/par2/par2_integration_test.go
@@ -148,8 +148,12 @@ func TestIntegration_NativeExecutor_SkipsWhenPar2FilesExistInTempDir(t *testing.
 	tempDir := t.TempDir()
 
 	sourcePath := createIntegrationTestFile(t, sourceDir, "archive.rar", 512*1024)
-	// PAR2 files live only in tempDir, not in sourceDir.
-	mainPar2, _ := createRealPar2Files(t, tempDir, sourcePath)
+	// PAR2 files live only in the temp work dir, not in sourceDir.
+	workDir := filepath.Join(tempDir, WorkSubdir)
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mainPar2, _ := createRealPar2Files(t, workDir, sourcePath)
 
 	cfg := &config.Par2Config{
 		Redundancy: "10",

--- a/internal/par2/par2_test.go
+++ b/internal/par2/par2_test.go
@@ -324,7 +324,7 @@ func TestCreate(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		createdFiles, err := executor.Create(context.Background(), files)
+		createdFiles, err := all(executor.Create(context.Background(), files))
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
@@ -378,7 +378,7 @@ func TestCreate(t *testing.T) {
 			{Path: filepath.Join(tempDir, "existing.par2"), Size: 1000},
 		}
 
-		createdFiles, err := executor.Create(context.Background(), files)
+		createdFiles, err := all(executor.Create(context.Background(), files))
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
@@ -413,10 +413,14 @@ func TestCreate(t *testing.T) {
 			{Path: testFile, Size: 50000},
 		}
 
-		createdFiles, err := executor.Create(context.Background(), files)
+		res, err := executor.Create(context.Background(), files)
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
+		if len(res.Created) != 0 || len(res.Reused) == 0 {
+			t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+		}
+		createdFiles := res.All()
 
 		// Should return existing files
 		if len(createdFiles) < 2 {
@@ -462,7 +466,7 @@ func TestCreate(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		createdFiles, err := executor.Create(context.Background(), files)
+		createdFiles, err := all(executor.Create(context.Background(), files))
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
@@ -505,10 +509,14 @@ func TestCreate(t *testing.T) {
 			{Path: testFile, Size: 50000},
 		}
 
-		createdFiles, err := executor.Create(context.Background(), files)
+		res, err := executor.Create(context.Background(), files)
 		if err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
+		if len(res.Created) != 0 || len(res.Reused) == 0 {
+			t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+		}
+		createdFiles := res.All()
 
 		// Should return existing files from source dir, not generate new ones in TempDir
 		if len(createdFiles) < 2 {
@@ -564,7 +572,7 @@ func TestCreate(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		_, err := executor.Create(ctx, files)
+		_, err := all(executor.Create(ctx, files))
 		if err == nil {
 			t.Error("Expected error from cancelled context")
 		}
@@ -592,7 +600,7 @@ func TestCreateInDirectory(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, outputDir)
+		createdFiles, err := all(executor.CreateInDirectory(context.Background(), files, outputDir))
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
@@ -639,7 +647,7 @@ func TestCreateInDirectory(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, "")
+		createdFiles, err := all(executor.CreateInDirectory(context.Background(), files, ""))
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
@@ -678,10 +686,14 @@ func TestCreateInDirectory(t *testing.T) {
 			{Path: testFile, Size: 50000},
 		}
 
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, outputDir)
+		res, err := executor.CreateInDirectory(context.Background(), files, outputDir)
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
+		if len(res.Created) != 0 || len(res.Reused) == 0 {
+			t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+		}
+		createdFiles := res.All()
 
 		if len(createdFiles) < 2 {
 			t.Fatalf("Expected at least 2 existing PAR2 files, got %d", len(createdFiles))
@@ -731,10 +743,14 @@ func TestCreateInDirectory(t *testing.T) {
 		}
 
 		// Call with empty outputDir — should detect par2 in source dir, not regenerate in TempDir
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, "")
+		res, err := executor.CreateInDirectory(context.Background(), files, "")
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
+		if len(res.Created) != 0 || len(res.Reused) == 0 {
+			t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+		}
+		createdFiles := res.All()
 
 		if len(createdFiles) < 2 {
 			t.Fatalf("Expected at least 2 existing PAR2 files, got %d", len(createdFiles))
@@ -791,10 +807,14 @@ func TestCreateInDirectory(t *testing.T) {
 		}
 
 		// Call with outputDir — should detect par2 in source dir, not regenerate in outputDir
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, outputDir)
+		res, err := executor.CreateInDirectory(context.Background(), files, outputDir)
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
+		if len(res.Created) != 0 || len(res.Reused) == 0 {
+			t.Fatalf("pre-existing PAR2 must be reported as reused, got Created=%v Reused=%v", res.Created, res.Reused)
+		}
+		createdFiles := res.All()
 
 		if len(createdFiles) < 2 {
 			t.Fatalf("Expected at least 2 existing PAR2 files, got %d", len(createdFiles))
@@ -850,7 +870,7 @@ func TestCreateInDirectory(t *testing.T) {
 			{Path: testFile, Size: 100000},
 		}
 
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, nestedOutputDir)
+		createdFiles, err := all(executor.CreateInDirectory(context.Background(), files, nestedOutputDir))
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}
@@ -898,7 +918,7 @@ func TestCreateInDirectory(t *testing.T) {
 			{Path: testFile3, Size: 50000},
 		}
 
-		createdFiles, err := executor.CreateInDirectory(context.Background(), files, outputDir)
+		createdFiles, err := all(executor.CreateInDirectory(context.Background(), files, outputDir))
 		if err != nil {
 			t.Fatalf("CreateInDirectory failed: %v", err)
 		}

--- a/internal/par2/par2_test.go
+++ b/internal/par2/par2_test.go
@@ -657,7 +657,7 @@ func TestCreateInDirectory(t *testing.T) {
 		}
 
 		// Should be created in configTempDir
-		expectedPar2File := filepath.Join(configTempDir, "testfile.bin.par2")
+		expectedPar2File := filepath.Join(configTempDir, WorkSubdir, "testfile.bin.par2")
 		if _, err := os.Stat(expectedPar2File); os.IsNotExist(err) {
 			t.Fatalf("Expected PAR2 file %s was not created in config temp directory", expectedPar2File)
 		}

--- a/internal/par2/par2_test.go
+++ b/internal/par2/par2_test.go
@@ -399,12 +399,7 @@ func TestCreate(t *testing.T) {
 		// Pre-create PAR2 files
 		mainPar2 := filepath.Join(tempDir, "testfile.bin.par2")
 		volPar2 := filepath.Join(tempDir, "testfile.bin.vol00+01.par2")
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
-		}
-		if err := os.WriteFile(volPar2, []byte("volume data"), 0644); err != nil {
-			t.Fatalf("failed to write vol par2 file: %v", err)
-		}
+		writeRealPar2Files(t, filepath.Dir(mainPar2), testFile, 1)
 
 		executor := &NativeExecutor{
 			articleSize: 10000,
@@ -495,12 +490,7 @@ func TestCreate(t *testing.T) {
 		// Pre-create PAR2 files in the SOURCE directory (not in TempDir)
 		mainPar2 := filepath.Join(sourceDir, "testfile.bin.par2")
 		volPar2 := filepath.Join(sourceDir, "testfile.bin.vol00+01.par2")
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
-		}
-		if err := os.WriteFile(volPar2, []byte("volume data"), 0644); err != nil {
-			t.Fatalf("failed to write vol par2 file: %v", err)
-		}
+		writeRealPar2Files(t, filepath.Dir(mainPar2), testFile, 1)
 
 		executor := &NativeExecutor{
 			articleSize: 10000,
@@ -673,13 +663,8 @@ func TestCreateInDirectory(t *testing.T) {
 
 		// Pre-create PAR2 files in output directory
 		mainPar2 := filepath.Join(outputDir, "testfile.bin.par2")
-		volPar2 := filepath.Join(outputDir, "testfile.bin.vol0+1.par2")
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
-		}
-		if err := os.WriteFile(volPar2, []byte("volume data"), 0644); err != nil {
-			t.Fatalf("failed to write vol par2 file: %v", err)
-		}
+		volPar2 := filepath.Join(outputDir, "testfile.bin.vol00+01.par2")
+		writeRealPar2Files(t, filepath.Dir(mainPar2), testFile, 1)
 
 		executor := &NativeExecutor{
 			articleSize: 10000,
@@ -730,12 +715,7 @@ func TestCreateInDirectory(t *testing.T) {
 		// Pre-create PAR2 files in the SOURCE directory (not TempDir)
 		mainPar2 := filepath.Join(sourceDir, "testfile.bin.par2")
 		volPar2 := filepath.Join(sourceDir, "testfile.bin.vol00+01.par2")
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
-		}
-		if err := os.WriteFile(volPar2, []byte("volume data"), 0644); err != nil {
-			t.Fatalf("failed to write vol par2 file: %v", err)
-		}
+		writeRealPar2Files(t, filepath.Dir(mainPar2), testFile, 1)
 
 		executor := &NativeExecutor{
 			articleSize: 10000,
@@ -796,12 +776,7 @@ func TestCreateInDirectory(t *testing.T) {
 		// Pre-create PAR2 files in the SOURCE directory (not outputDir)
 		mainPar2 := filepath.Join(sourceDir, "testfile.bin.par2")
 		volPar2 := filepath.Join(sourceDir, "testfile.bin.vol00+01.par2")
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
-		}
-		if err := os.WriteFile(volPar2, []byte("volume data"), 0644); err != nil {
-			t.Fatalf("failed to write vol par2 file: %v", err)
-		}
+		writeRealPar2Files(t, filepath.Dir(mainPar2), testFile, 1)
 
 		executor := &NativeExecutor{
 			articleSize: 10000,
@@ -957,29 +932,24 @@ func TestCheckExistingPar2FilesInDir(t *testing.T) {
 		ctx := context.Background()
 		tempDir := t.TempDir()
 
+		sourceDir := filepath.Join(tempDir, "source")
+		if err := os.MkdirAll(sourceDir, 0755); err != nil {
+			t.Fatal(err)
+		}
 		sourceFile := fileinfo.FileInfo{
-			Path: filepath.Join(tempDir, "source", "testfile.bin"),
+			Path: filepath.Join(sourceDir, "testfile.bin"),
 			Size: 1024 * 1024,
 		}
+		createTestFile(t, sourceFile.Path, 1024*1024)
 
-		// Create PAR2 files in directory
-		mainPar2 := filepath.Join(tempDir, "testfile.bin.par2")
-		vol1 := filepath.Join(tempDir, "testfile.bin.vol0+1.par2")
-		vol2 := filepath.Join(tempDir, "testfile.bin.vol1+2.par2")
-		vol3 := filepath.Join(tempDir, "testfile.bin.vol3+4.par2")
-
-		if err := os.WriteFile(mainPar2, []byte("par2 data"), 0644); err != nil {
-			t.Fatalf("failed to write par2 file: %v", err)
+		// Create a real PAR2 set in directory with several recovery volumes.
+		mainPar2 := writeRealPar2Files(t, tempDir, sourceFile.Path, 7)
+		volumes, err := filepath.Glob(filepath.Join(tempDir, "testfile.bin.vol*.par2"))
+		if err != nil || len(volumes) < 2 {
+			t.Fatalf("expected several volume files, got %v (err=%v)", volumes, err)
 		}
-		if err := os.WriteFile(vol1, []byte("volume 1 data"), 0644); err != nil {
-			t.Fatalf("failed to write vol1 file: %v", err)
-		}
-		if err := os.WriteFile(vol2, []byte("volume 2 data"), 0644); err != nil {
-			t.Fatalf("failed to write vol2 file: %v", err)
-		}
-		if err := os.WriteFile(vol3, []byte("volume 3 data"), 0644); err != nil {
-			t.Fatalf("failed to write vol3 file: %v", err)
-		}
+		want := append([]string{mainPar2}, volumes...)
+		slices.Sort(want)
 
 		executor := &NativeExecutor{
 			articleSize: 512 * 1024,
@@ -994,40 +964,9 @@ func TestCheckExistingPar2FilesInDir(t *testing.T) {
 		if !exists {
 			t.Fatal("Expected existing PAR2 files to be detected")
 		}
-
-		if len(paths) != 4 {
-			t.Fatalf("Expected 4 PAR2 files (1 main + 3 volumes), got %d", len(paths))
-		}
-
-		foundMain := false
-		foundVol1 := false
-		foundVol2 := false
-		foundVol3 := false
-
-		for _, path := range paths {
-			switch path {
-			case mainPar2:
-				foundMain = true
-			case vol1:
-				foundVol1 = true
-			case vol2:
-				foundVol2 = true
-			case vol3:
-				foundVol3 = true
-			}
-		}
-
-		if !foundMain {
-			t.Error("Main PAR2 file not found in returned paths")
-		}
-		if !foundVol1 {
-			t.Error("Volume 1 file not found in returned paths")
-		}
-		if !foundVol2 {
-			t.Error("Volume 2 file not found in returned paths")
-		}
-		if !foundVol3 {
-			t.Error("Volume 3 file not found in returned paths")
+		slices.Sort(paths)
+		if !slices.Equal(paths, want) {
+			t.Fatalf("paths = %v, want %v", paths, want)
 		}
 	})
 

--- a/internal/par2/scheduler.go
+++ b/internal/par2/scheduler.go
@@ -34,12 +34,12 @@ func NewScheduler(maxConcurrentJobs int) *Scheduler {
 // slot. If ctx is cancelled while waiting for a slot, Run returns ctx.Err()
 // without invoking fn. fn itself should honour ctx so that active work can be
 // cancelled too.
-func (s *Scheduler) Run(ctx context.Context, fn func() ([]string, error)) ([]string, error) {
+func (s *Scheduler) Run(ctx context.Context, fn func() (Result, error)) (Result, error) {
 	s.queued.Add(1)
 	select {
 	case <-ctx.Done():
 		s.queued.Add(-1)
-		return nil, ctx.Err()
+		return Result{}, ctx.Err()
 	case s.sem <- struct{}{}:
 		s.queued.Add(-1)
 	}
@@ -79,20 +79,20 @@ func NewScheduledExecutor(inner Par2Executor, sched *Scheduler) Par2Executor {
 	return &ScheduledExecutor{inner: inner, sched: sched}
 }
 
-func (e *ScheduledExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) ([]string, error) {
-	return e.sched.Run(ctx, func() ([]string, error) {
+func (e *ScheduledExecutor) Create(ctx context.Context, files []fileinfo.FileInfo) (Result, error) {
+	return e.sched.Run(ctx, func() (Result, error) {
 		return e.inner.Create(ctx, files)
 	})
 }
 
-func (e *ScheduledExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) ([]string, error) {
-	return e.sched.Run(ctx, func() ([]string, error) {
+func (e *ScheduledExecutor) CreateInDirectory(ctx context.Context, files []fileinfo.FileInfo, outputDir string) (Result, error) {
+	return e.sched.Run(ctx, func() (Result, error) {
 		return e.inner.CreateInDirectory(ctx, files, outputDir)
 	})
 }
 
-func (e *ScheduledExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) ([]string, error) {
-	return e.sched.Run(ctx, func() ([]string, error) {
+func (e *ScheduledExecutor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, setName, folderDir string) (Result, error) {
+	return e.sched.Run(ctx, func() (Result, error) {
 		return e.inner.CreateSet(ctx, files, outputDir, setName, folderDir)
 	})
 }

--- a/internal/par2/scheduler_test.go
+++ b/internal/par2/scheduler_test.go
@@ -25,7 +25,7 @@ func newFakeExecutor() *fakeExecutor {
 	return &fakeExecutor{release: make(chan struct{})}
 }
 
-func (f *fakeExecutor) run(ctx context.Context) ([]string, error) {
+func (f *fakeExecutor) run(ctx context.Context) (Result, error) {
 	f.calls.Add(1)
 	f.mu.Lock()
 	f.inFlight++
@@ -42,19 +42,19 @@ func (f *fakeExecutor) run(ctx context.Context) ([]string, error) {
 
 	select {
 	case <-f.release:
-		return []string{"ok"}, nil
+		return Result{Created: []string{"ok"}}, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return Result{}, ctx.Err()
 	}
 }
 
-func (f *fakeExecutor) Create(ctx context.Context, _ []fileinfo.FileInfo) ([]string, error) {
+func (f *fakeExecutor) Create(ctx context.Context, _ []fileinfo.FileInfo) (Result, error) {
 	return f.run(ctx)
 }
-func (f *fakeExecutor) CreateInDirectory(ctx context.Context, _ []fileinfo.FileInfo, _ string) ([]string, error) {
+func (f *fakeExecutor) CreateInDirectory(ctx context.Context, _ []fileinfo.FileInfo, _ string) (Result, error) {
 	return f.run(ctx)
 }
-func (f *fakeExecutor) CreateSet(ctx context.Context, _ []fileinfo.FileInfo, _, _, _ string) ([]string, error) {
+func (f *fakeExecutor) CreateSet(ctx context.Context, _ []fileinfo.FileInfo, _, _, _ string) (Result, error) {
 	return f.run(ctx)
 }
 

--- a/internal/par2sweep/sweep.go
+++ b/internal/par2sweep/sweep.go
@@ -1,0 +1,115 @@
+// Package par2sweep removes orphaned PAR2 files from Postie's PAR2 work
+// directory. Generated sets are normally deleted by the transfer cleaner once
+// the transfer is verified, but when the transfer rows disappear first (a
+// database reset, an old crash) nothing else ever removes them and the work
+// dir grows by the redundancy share of every abandoned upload.
+package par2sweep
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kipsilabs/postie/internal/par2"
+)
+
+// Sweeper deletes PAR2 files in dir that are older than grace, not referenced
+// by any transfer and not in use by a running job. It only ever looks at the
+// top level of dir, which must be a directory Postie owns exclusively.
+type Sweeper struct {
+	dir        string
+	grace      time.Duration
+	referenced func(context.Context) ([]string, error)
+	inUse      func() []string
+	now        func() time.Time
+}
+
+// New builds a Sweeper. referenced returns the source paths of every file the
+// durable store still tracks (nil when there is no store); inUse returns the
+// PAR2 files of jobs currently running (nil when not tracked).
+func New(dir string, grace time.Duration, referenced func(context.Context) ([]string, error), inUse func() []string) *Sweeper {
+	return &Sweeper{dir: dir, grace: grace, referenced: referenced, inUse: inUse, now: time.Now}
+}
+
+// Sweep runs one pass and returns how many files it removed. A failing
+// referenced lookup aborts the pass without deleting anything, since orphans
+// cannot be told apart from sets still awaiting verification.
+func (s *Sweeper) Sweep(ctx context.Context) (int, error) {
+	if s.dir == "" {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	keep := map[string]struct{}{}
+	if s.referenced != nil {
+		paths, err := s.referenced(ctx)
+		if err != nil {
+			return 0, err
+		}
+		for _, p := range paths {
+			keep[p] = struct{}{}
+		}
+	}
+	if s.inUse != nil {
+		for _, p := range s.inUse() {
+			keep[p] = struct{}{}
+		}
+	}
+
+	cutoff := s.now().Add(-s.grace)
+	removed := 0
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return removed, ctx.Err()
+		}
+		if entry.IsDir() || !par2.IsPar2File(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(s.dir, entry.Name())
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.WarnContext(ctx, "Failed to remove orphaned PAR2 file", "path", path, "error", err)
+			continue
+		}
+		slog.InfoContext(ctx, "Removed orphaned PAR2 file", "path", path, "age", s.now().Sub(info.ModTime()).Round(time.Minute))
+		removed++
+	}
+	return removed, nil
+}
+
+// Run waits initialDelay, sweeps, and then sweeps every interval until ctx is
+// cancelled. The delay gives jobs resumed at startup time to reserve the sets
+// they are about to reuse before the first pass.
+func (s *Sweeper) Run(ctx context.Context, initialDelay, interval time.Duration) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(initialDelay):
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if _, err := s.Sweep(ctx); err != nil && ctx.Err() == nil {
+			slog.WarnContext(ctx, "PAR2 work dir sweep failed", "dir", s.dir, "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/par2sweep/sweep_test.go
+++ b/internal/par2sweep/sweep_test.go
@@ -1,0 +1,120 @@
+package par2sweep
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeAged(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Now().Add(-age)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Orphaned PAR2 sets accumulate in the shared work dir when the transfer rows
+// are dropped (database reset) before the cleaner runs. The sweeper removes
+// PAR2 files that are old, not referenced by any transfer and not in use by a
+// running job, and nothing else.
+func TestSweep(t *testing.T) {
+	dir := t.TempDir()
+	old := 48 * time.Hour
+
+	orphan := filepath.Join(dir, "movie.mkv.par2")
+	orphanVol := filepath.Join(dir, "movie.mkv.vol00+01.par2")
+	referenced := filepath.Join(dir, "show.mkv.par2")
+	inUse := filepath.Join(dir, "busy.mkv.vol00+01.par2")
+	young := filepath.Join(dir, "fresh.mkv.par2")
+	notPar2 := filepath.Join(dir, "notes.txt")
+	for _, p := range []string{orphan, orphanVol, referenced, inUse, notPar2} {
+		writeAged(t, p, old)
+	}
+	writeAged(t, young, time.Minute)
+	if err := os.Mkdir(filepath.Join(dir, "sub.par2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(dir, 24*time.Hour,
+		func(context.Context) ([]string, error) { return []string{referenced}, nil },
+		func() []string { return []string{inUse} },
+	)
+	removed, err := s.Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("removed = %d, want 2", removed)
+	}
+	for _, p := range []string{orphan, orphanVol} {
+		if exists(p) {
+			t.Errorf("%s should have been removed", filepath.Base(p))
+		}
+	}
+	for _, p := range []string{referenced, inUse, young, notPar2, filepath.Join(dir, "sub.par2")} {
+		if !exists(p) {
+			t.Errorf("%s must be kept", filepath.Base(p))
+		}
+	}
+}
+
+func TestSweep_NoDirIsNoop(t *testing.T) {
+	for _, dir := range []string{"", filepath.Join(t.TempDir(), "missing")} {
+		s := New(dir, time.Hour, nil, nil)
+		if n, err := s.Sweep(context.Background()); err != nil || n != 0 {
+			t.Errorf("dir %q: removed=%d err=%v", dir, n, err)
+		}
+	}
+}
+
+// When the referenced-paths lookup fails nothing may be deleted: we cannot tell
+// orphans from sets still awaiting verification.
+func TestSweep_KeepsEverythingWhenLookupFails(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "movie.mkv.par2")
+	writeAged(t, p, 48*time.Hour)
+
+	s := New(dir, time.Hour, func(context.Context) ([]string, error) { return nil, os.ErrClosed }, nil)
+	if _, err := s.Sweep(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+	if !exists(p) {
+		t.Fatal("file must survive a failed lookup")
+	}
+}
+
+func TestRun_WaitsInitialDelayBeforeFirstSweep(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "movie.mkv.par2")
+	writeAged(t, p, 48*time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	s := New(dir, time.Hour, nil, nil)
+	go func() { s.Run(ctx, 200*time.Millisecond, time.Hour); close(done) }()
+
+	time.Sleep(50 * time.Millisecond)
+	if !exists(p) {
+		t.Fatal("file removed before the initial delay elapsed")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for exists(p) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if exists(p) {
+		t.Fatal("file not removed after the initial delay")
+	}
+	cancel()
+	<-done
+}

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -183,6 +183,7 @@ func (p *Processor) Start(ctx context.Context) error {
 	p.startVerificationOnce.Do(func() {
 		if p.transferRuntime != nil {
 			go p.transferRuntime.RunVerification(ctx)
+			go p.transferRuntime.RunPar2Sweeper(ctx)
 		}
 	})
 

--- a/internal/transferstore/transferstore.go
+++ b/internal/transferstore/transferstore.go
@@ -246,6 +246,27 @@ func (s *Store) ListFilesByTransfer(ctx context.Context, transferID string) ([]T
 	return out, rows.Err()
 }
 
+// ListSourcePaths returns every distinct source path still tracked by a
+// transfer, whatever its state. The PAR2 sweeper uses it to keep files that a
+// pending or in-progress transfer may still need.
+func (s *Store) ListSourcePaths(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT DISTINCT source_path FROM transfer_files")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
 // SetVerificationState updates a file's verification state, next check time and
 // last error in one statement.
 func (s *Store) SetVerificationState(ctx context.Context, transferID, fileID, state string, nextCheckAt *time.Time, lastErr string) error {

--- a/internal/transferstore/transferstore_test.go
+++ b/internal/transferstore/transferstore_test.go
@@ -345,3 +345,24 @@ func TestMigrateLegacyPendingChecks(t *testing.T) {
 		t.Errorf("second migration = %d,%v, want 0,nil", n2, err)
 	}
 }
+
+func TestListSourcePaths(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for i, tf := range []TransferFile{
+		{TransferID: "t1", FileID: "a", SourcePath: "/x/a.mkv", ManifestPath: "/m/a", FileRole: "original", UploadState: StatePlanned, VerificationState: StatePlanned},
+		{TransferID: "t1", FileID: "b", SourcePath: "/x/a.mkv.par2", ManifestPath: "/m/b", FileRole: "generated_par2", UploadState: StatePlanned, VerificationState: StatePlanned},
+		{TransferID: "t2", FileID: "c", SourcePath: "/x/a.mkv.par2", ManifestPath: "/m/c", FileRole: "generated_par2", UploadState: StatePlanned, VerificationState: StatePlanned},
+	} {
+		if err := s.UpsertFile(ctx, tf); err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+	}
+	got, err := s.ListSourcePaths(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListSourcePaths = %v, want 2 distinct paths", got)
+	}
+}

--- a/internal/transferwriter/transferwriter.go
+++ b/internal/transferwriter/transferwriter.go
@@ -12,11 +12,11 @@ import (
 	"errors"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/kipsilabs/postie/internal/article"
 	"github.com/kipsilabs/postie/internal/manifest"
-	"github.com/kipsilabs/postie/internal/par2"
 	"github.com/kipsilabs/postie/internal/transferstore"
 )
 
@@ -26,12 +26,28 @@ type Recorder struct {
 	transferID string
 	baseDir    string
 	store      *transferstore.Store
+
+	mu        sync.Mutex
+	generated map[string]struct{}
 }
 
 // New creates a Recorder for transferID that writes manifests under baseDir and
 // persists rows through store.
 func New(transferID, baseDir string, store *transferstore.Store) *Recorder {
-	return &Recorder{transferID: transferID, baseDir: baseDir, store: store}
+	return &Recorder{transferID: transferID, baseDir: baseDir, store: store, generated: map[string]struct{}{}}
+}
+
+// MarkGenerated records that Postie itself wrote paths (PAR2 files) for this
+// transfer. Only such files are recorded with the generated_par2 role, which
+// lets the transfer cleaner delete them once verified. Any other file, PAR2
+// or not, is an original the user placed there and is treated as such. Call
+// it before the files' articles are recorded.
+func (r *Recorder) MarkGenerated(paths ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, p := range paths {
+		r.generated[p] = struct{}{}
+	}
 }
 
 // fileID derives a stable identifier for a source path so re-recording the same
@@ -41,9 +57,11 @@ func fileID(sourcePath string) string {
 	return hex.EncodeToString(sum[:8])
 }
 
-// roleFor classifies a file by its on-disk path.
-func roleFor(sourcePath string) manifest.FileRole {
-	if par2.IsPar2File(sourcePath) {
+// roleFor classifies a file by whether Postie generated it (see MarkGenerated).
+func (r *Recorder) roleFor(sourcePath string) manifest.FileRole {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.generated[sourcePath]; ok {
 		return manifest.RoleGeneratedPar2
 	}
 	return manifest.RoleOriginal
@@ -55,7 +73,7 @@ func roleFor(sourcePath string) manifest.FileRole {
 // posted so the manifest is durable first.
 func (r *Recorder) RecordFile(ctx context.Context, sourcePath string, articles []*article.Article) error {
 	fid := fileID(sourcePath)
-	role := roleFor(sourcePath)
+	role := r.roleFor(sourcePath)
 	manifestPath := manifest.FilePath(r.baseDir, r.transferID, fid)
 
 	w, err := manifest.NewWriter(manifestPath)

--- a/internal/transferwriter/transferwriter_test.go
+++ b/internal/transferwriter/transferwriter_test.go
@@ -86,20 +86,37 @@ func TestRecorder_WritesManifestAndRow(t *testing.T) {
 	}
 }
 
-func TestRecorder_InfersPar2Role(t *testing.T) {
+// A PAR2 file is only "generated" when Postie says it created it. A PAR2 file
+// the user placed next to the sources and that Postie merely reused must be
+// recorded as an original, or the cleaner deletes the user's own files
+// (kipsilabs/postie#274).
+func TestRecorder_RoleComesFromMarkGenerated(t *testing.T) {
 	store := newTestStore(t)
 	rec := New("tid-2", t.TempDir(), store)
 	ctx := context.Background()
 
-	if err := rec.RecordFile(ctx, "/data/movie.vol00+1.par2", []*article.Article{
-		{MessageID: "x@p", Offset: 0, Size: 5},
-	}); err != nil {
-		t.Fatalf("RecordFile: %v", err)
+	rec.MarkGenerated("/tmp/movie.mkv.par2", "/tmp/movie.mkv.vol00+01.par2")
+
+	cases := map[string]manifest.FileRole{
+		"/tmp/movie.mkv.par2":          manifest.RoleGeneratedPar2,
+		"/tmp/movie.mkv.vol00+01.par2": manifest.RoleGeneratedPar2,
+		"/data/movie.vol00+1.par2":     manifest.RoleOriginal, // user-supplied, reused
+		"/data/movie.mkv":              manifest.RoleOriginal,
+	}
+	for path := range cases {
+		if err := rec.RecordFile(ctx, path, []*article.Article{{MessageID: "x@p", Offset: 0, Size: 5}}); err != nil {
+			t.Fatalf("RecordFile(%s): %v", path, err)
+		}
 	}
 
 	files, _ := store.ListFilesByTransfer(ctx, "tid-2")
-	if len(files) != 1 || files[0].FileRole != string(manifest.RoleGeneratedPar2) {
-		t.Errorf("expected generated_par2 role, got %+v", files)
+	if len(files) != len(cases) {
+		t.Fatalf("expected %d rows, got %d", len(cases), len(files))
+	}
+	for _, f := range files {
+		if want := cases[f.SourcePath]; f.FileRole != string(want) {
+			t.Errorf("%s: role = %q, want %q", f.SourcePath, f.FileRole, want)
+		}
 	}
 }
 

--- a/pkg/postie/par2_inuse_test.go
+++ b/pkg/postie/par2_inuse_test.go
@@ -1,0 +1,48 @@
+package postie
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/kipsilabs/postie/internal/par2"
+)
+
+// Every PAR2 file a running job posts, created or reused, must be reported as
+// in use until the job closes, so the sweeper never deletes a set that is
+// still being posted. A reused set in the work dir may be an old orphan that
+// no transfer row protects yet.
+func TestPar2InUseTrackedUntilClose(t *testing.T) {
+	for name, mk := range map[string]func(dir string) par2.Par2Executor{
+		"created": func(dir string) par2.Par2Executor { return &par2InDir{dir: dir} },
+		"reused":  func(dir string) par2.Par2Executor { return &par2Reused{dir: dir} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			rt := &Runtime{}
+			root := t.TempDir()
+			files, cleanup := makeSourceFiles(t, root, "Folder", "video.mkv")
+			defer cleanup()
+			par2Dir := t.TempDir()
+
+			p := newTestPostie(nil, true, true) // maintain_par2_files: keep files so reservation is observable
+			p.par2runner = mk(par2Dir)
+			p.par2Reserver = rt
+
+			if _, err := p.post(context.Background(), files[0], root, t.TempDir()); err != nil {
+				t.Fatal(err)
+			}
+			inUse := rt.Par2InUse()
+			slices.Sort(inUse)
+			want := []string{filepath.Join(par2Dir, "video.mkv.par2"), filepath.Join(par2Dir, "video.mkv.vol0+1.par2")}
+			if !slices.Equal(inUse, want) {
+				t.Fatalf("Par2InUse = %v, want %v", inUse, want)
+			}
+
+			p.Close()
+			if left := rt.Par2InUse(); len(left) != 0 {
+				t.Fatalf("after Close Par2InUse = %v, want none", left)
+			}
+		})
+	}
+}

--- a/pkg/postie/par2_retention_test.go
+++ b/pkg/postie/par2_retention_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kipsilabs/postie/internal/par2"
 	"github.com/kipsilabs/postie/internal/transferwriter"
 	"github.com/kipsilabs/postie/pkg/fileinfo"
 )
@@ -14,29 +15,58 @@ import (
 // the default behaviour (no output dir configured → temp/source dir).
 type par2InDir struct{ dir string }
 
-func (m *par2InDir) create(setName string) ([]string, error) {
+func (m *par2InDir) create(setName string) (par2.Result, error) {
 	paths := []string{
 		filepath.Join(m.dir, setName+".par2"),
 		filepath.Join(m.dir, setName+".vol0+1.par2"),
 	}
 	for _, p := range paths {
 		if err := os.WriteFile(p, []byte("par2"), 0644); err != nil {
-			return nil, err
+			return par2.Result{}, err
 		}
 	}
-	return paths, nil
+	return par2.Result{Created: paths}, nil
 }
 
-func (m *par2InDir) Create(_ context.Context, files []fileinfo.FileInfo) ([]string, error) {
+func (m *par2InDir) Create(_ context.Context, files []fileinfo.FileInfo) (par2.Result, error) {
 	return m.create(filepath.Base(files[0].Path))
 }
 
-func (m *par2InDir) CreateInDirectory(_ context.Context, files []fileinfo.FileInfo, _ string) ([]string, error) {
+func (m *par2InDir) CreateInDirectory(_ context.Context, files []fileinfo.FileInfo, _ string) (par2.Result, error) {
 	return m.create(filepath.Base(files[0].Path))
 }
 
-func (m *par2InDir) CreateSet(_ context.Context, _ []fileinfo.FileInfo, _, setName, _ string) ([]string, error) {
+func (m *par2InDir) CreateSet(_ context.Context, _ []fileinfo.FileInfo, _, setName, _ string) (par2.Result, error) {
 	return m.create(setName)
+}
+
+// par2Reused is a PAR2 executor that reports a pre-existing set in dir, as
+// when the user shipped their own PAR2 files next to the sources.
+type par2Reused struct{ dir string }
+
+func (m *par2Reused) reuse(setName string) (par2.Result, error) {
+	paths := []string{
+		filepath.Join(m.dir, setName+".par2"),
+		filepath.Join(m.dir, setName+".vol0+1.par2"),
+	}
+	for _, p := range paths {
+		if err := os.WriteFile(p, []byte("par2"), 0644); err != nil {
+			return par2.Result{}, err
+		}
+	}
+	return par2.Result{Reused: paths}, nil
+}
+
+func (m *par2Reused) Create(_ context.Context, files []fileinfo.FileInfo) (par2.Result, error) {
+	return m.reuse(filepath.Base(files[0].Path))
+}
+
+func (m *par2Reused) CreateInDirectory(_ context.Context, files []fileinfo.FileInfo, _ string) (par2.Result, error) {
+	return m.reuse(filepath.Base(files[0].Path))
+}
+
+func (m *par2Reused) CreateSet(_ context.Context, _ []fileinfo.FileInfo, _, setName, _ string) (par2.Result, error) {
+	return m.reuse(setName)
 }
 
 func par2FilesLeft(t *testing.T, dir string) int {
@@ -113,6 +143,30 @@ func TestPar2CleanedAfterPostInStandaloneMode(t *testing.T) {
 			}
 			if n := par2FilesLeft(t, par2Dir); n != 0 {
 				t.Errorf("%s: %d PAR2 files left, want 0 in standalone mode", name, n)
+			}
+		})
+	}
+}
+
+// TestPreexistingPar2NeverDeleted: PAR2 files Postie did not create (the user's
+// own, reused from the source folder) must survive posting even in standalone
+// mode with maintain_par2_files off (kipsilabs/postie#274).
+func TestPreexistingPar2NeverDeleted(t *testing.T) {
+	for name, run := range postPaths {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			files, cleanup := makeSourceFiles(t, root, "Folder", "video.mkv")
+			defer cleanup()
+			par2Dir := t.TempDir()
+
+			p := newTestPostie(nil, true, false)
+			p.par2runner = &par2Reused{dir: par2Dir}
+
+			if err := run(p, context.Background(), files, root, t.TempDir()); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if n := par2FilesLeft(t, par2Dir); n != 2 {
+				t.Errorf("%s: %d PAR2 files left, want 2 (reused files are not Postie's to delete)", name, n)
 			}
 		})
 	}

--- a/pkg/postie/postfolder_test.go
+++ b/pkg/postie/postfolder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kipsilabs/postie/internal/article"
 	"github.com/kipsilabs/postie/internal/config"
 	"github.com/kipsilabs/postie/internal/nzb"
+	"github.com/kipsilabs/postie/internal/par2"
 	"github.com/kipsilabs/postie/internal/poster"
 	"github.com/kipsilabs/postie/pkg/fileinfo"
 )
@@ -58,30 +59,30 @@ type mockPar2Executor struct {
 	par2FileNames []string
 }
 
-func (m *mockPar2Executor) Create(_ context.Context, _ []fileinfo.FileInfo) ([]string, error) {
-	return nil, nil
+func (m *mockPar2Executor) Create(_ context.Context, _ []fileinfo.FileInfo) (par2.Result, error) {
+	return par2.Result{}, nil
 }
 
-func (m *mockPar2Executor) CreateInDirectory(_ context.Context, _ []fileinfo.FileInfo, outputDir string) ([]string, error) {
+func (m *mockPar2Executor) CreateInDirectory(_ context.Context, _ []fileinfo.FileInfo, outputDir string) (par2.Result, error) {
 	m.recordedOutputDir = outputDir
 	if outputDir == "" || len(m.par2FileNames) == 0 {
-		return nil, nil
+		return par2.Result{}, nil
 	}
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, err
+		return par2.Result{}, err
 	}
 	var created []string
 	for _, name := range m.par2FileNames {
 		p := filepath.Join(outputDir, name)
 		if err := os.WriteFile(p, []byte("dummy"), 0644); err != nil {
-			return nil, err
+			return par2.Result{}, err
 		}
 		created = append(created, p)
 	}
-	return created, nil
+	return par2.Result{Created: created}, nil
 }
 
-func (m *mockPar2Executor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, _, _ string) ([]string, error) {
+func (m *mockPar2Executor) CreateSet(ctx context.Context, files []fileinfo.FileInfo, outputDir, _, _ string) (par2.Result, error) {
 	return m.CreateInDirectory(ctx, files, outputDir)
 }
 

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kipsilabs/postie/internal/config"
@@ -39,10 +40,22 @@ type Postie struct {
 	// the transfer's files uploaded (for the durable verification service) once
 	// posting completes.
 	recorder *transferwriter.Recorder
+	// par2Reserver keeps the PAR2 files this job posts out of the work-dir
+	// sweeper's reach until Close. Nil when there is no runtime.
+	par2Reserver par2Reserver
+	// reservedPar2 accumulates the PAR2 files reserved for this job, for release.
+	reservedMu   sync.Mutex
+	reservedPar2 []string
 	// deleteOriginal records whether this job's originals should be deleted
 	// after successful verification (persisted into the transfer's cleanup
 	// policy at completion). Set by the caller before Post.
 	deleteOriginal bool
+}
+
+// par2Reserver is the subset of Runtime used to protect in-flight PAR2 files.
+type par2Reserver interface {
+	ReservePar2(paths ...string)
+	ReleasePar2(paths ...string)
 }
 
 // SetDeleteOriginal records whether the job's original files should be deleted
@@ -142,7 +155,17 @@ func NewWithRuntime(
 		jobProgress:               jobProgress,
 		queue:                     queue,
 		recorder:                  recorder,
+		par2Reserver:              reserverFor(rt),
 	}, nil
+}
+
+// reserverFor returns rt as a par2Reserver, or nil for a nil runtime so the
+// interface itself is nil (a typed nil pointer would not compare to nil).
+func reserverFor(rt *Runtime) par2Reserver {
+	if rt == nil {
+		return nil
+	}
+	return rt
 }
 
 // removePar2AfterPost reports whether generated PAR2 files should be deleted as
@@ -157,14 +180,26 @@ func (p *Postie) removePar2AfterPost() bool {
 	return p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files
 }
 
-// markGenerated tells the durable recorder which PAR2 files this job wrote, so
-// only those are recorded as generated (and later deleted by the cleaner).
-// Reused PAR2 files stay originals. No-op in standalone mode.
-func (p *Postie) markGenerated(res par2.Result) {
-	if p.recorder == nil || len(res.Created) == 0 {
+// trackGenerated registers the PAR2 files this job is about to post. The
+// durable recorder records only the ones Postie created as generated (so the
+// cleaner may delete them later, while reused PAR2 files stay originals). All
+// of them, reused included, are reserved so the work-dir sweeper cannot remove
+// a set between here and the end of the upload: a reused set in the work dir
+// may be an old orphan that no transfer row protects yet.
+func (p *Postie) trackGenerated(res par2.Result) {
+	all := res.All()
+	if len(all) == 0 {
 		return
 	}
-	p.recorder.MarkGenerated(res.Created...)
+	if p.recorder != nil && len(res.Created) > 0 {
+		p.recorder.MarkGenerated(res.Created...)
+	}
+	if p.par2Reserver != nil {
+		p.par2Reserver.ReservePar2(all...)
+	}
+	p.reservedMu.Lock()
+	p.reservedPar2 = append(p.reservedPar2, all...)
+	p.reservedMu.Unlock()
 }
 
 // completeTransferUpload marks the transfer's files uploaded so the durable
@@ -186,15 +221,20 @@ func (p *Postie) Close() {
 	if p.jobProgress != nil {
 		p.jobProgress.Close()
 	}
+	if p.par2Reserver != nil {
+		p.reservedMu.Lock()
+		paths := p.reservedPar2
+		p.reservedPar2 = nil
+		p.reservedMu.Unlock()
+		p.par2Reserver.ReleasePar2(paths...)
+	}
 }
 
 // CleanupPar2Files removes PAR2 files for the given source file
 // This method can be called when a job fails permanently to clean up orphaned PAR2 files
 func (p *Postie) CleanupPar2Files(ctx context.Context, sourceFile fileinfo.FileInfo) {
-	var dirPath string
-	if p.par2Cfg != nil && p.par2Cfg.TempDir != "" {
-		dirPath = p.par2Cfg.TempDir
-	} else {
+	dirPath := par2.WorkDir(p.par2Cfg)
+	if dirPath == "" {
 		dirPath = filepath.Dir(sourceFile.Path)
 	}
 
@@ -378,7 +418,7 @@ func (p *Postie) postInParallel(
 
 			return nil
 		}
-		p.markGenerated(par2Res)
+		p.trackGenerated(par2Res)
 
 		par2Paths := par2Res.All()
 		if err := p.poster.Post(ctx, par2Paths, rootDir, nzbGen); err != nil {
@@ -487,7 +527,7 @@ func (p *Postie) post(
 
 			return "", err
 		}
-		p.markGenerated(par2Res)
+		p.trackGenerated(par2Res)
 
 		filesPath = append(filesPath, par2Res.All()...)
 	}
@@ -625,7 +665,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 					}
 					// Continue without PAR2 files
 				} else {
-					p.markGenerated(par2Res)
+					p.trackGenerated(par2Res)
 					allFilePaths = append(allFilePaths, par2Res.All()...)
 					// par2 set files live at the folder root — basenames in NZB subjects.
 				}
@@ -695,7 +735,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 				}
 				return nil
 			}
-			p.markGenerated(par2Res)
+			p.trackGenerated(par2Res)
 
 			// par2 set files live at the folder root — basenames in NZB subjects.
 			par2Paths := par2Res.All()

--- a/pkg/postie/postie.go
+++ b/pkg/postie/postie.go
@@ -157,6 +157,16 @@ func (p *Postie) removePar2AfterPost() bool {
 	return p.par2Cfg.MaintainPar2Files == nil || !*p.par2Cfg.MaintainPar2Files
 }
 
+// markGenerated tells the durable recorder which PAR2 files this job wrote, so
+// only those are recorded as generated (and later deleted by the cleaner).
+// Reused PAR2 files stay originals. No-op in standalone mode.
+func (p *Postie) markGenerated(res par2.Result) {
+	if p.recorder == nil || len(res.Created) == 0 {
+		return
+	}
+	p.recorder.MarkGenerated(res.Created...)
+}
+
 // completeTransferUpload marks the transfer's files uploaded so the durable
 // verification service can verify them, scheduling the first check after the
 // configured propagation delay. No-op in standalone mode (no recorder).
@@ -325,7 +335,7 @@ func (p *Postie) postInParallel(
 	outputDir string,
 ) (string, error) {
 	var (
-		createdPar2Paths []string
+		par2Res          par2.Result
 		err              error
 		postingSucceeded bool
 	)
@@ -337,7 +347,7 @@ func (p *Postie) postInParallel(
 		}
 
 		if p.removePar2AfterPost() {
-			for _, path := range createdPar2Paths {
+			for _, path := range par2Res.Created {
 				safeRemoveFile(ctx, path)
 			}
 		}
@@ -360,7 +370,7 @@ func (p *Postie) postInParallel(
 		}
 		// If par2OutputDir is empty, CreateInDirectory will use default behavior (temp/source dir)
 
-		createdPar2Paths, err = p.par2runner.CreateInDirectory(ctx, []fileinfo.FileInfo{f}, par2OutputDir)
+		par2Res, err = p.par2runner.CreateInDirectory(ctx, []fileinfo.FileInfo{f}, par2OutputDir)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				slog.ErrorContext(ctx, "Error during par2 creation. Upload will continue without par2.", "error", err)
@@ -368,12 +378,14 @@ func (p *Postie) postInParallel(
 
 			return nil
 		}
+		p.markGenerated(par2Res)
 
-		if err := p.poster.Post(ctx, createdPar2Paths, rootDir, nzbGen); err != nil {
+		par2Paths := par2Res.All()
+		if err := p.poster.Post(ctx, par2Paths, rootDir, nzbGen); err != nil {
 			if !errors.Is(err, context.Canceled) {
-				slog.ErrorContext(ctx, fmt.Sprintf("Error during upload of par2 files: %s. Upload will continue without par2.", createdPar2Paths), "error", err)
+				slog.ErrorContext(ctx, fmt.Sprintf("Error during upload of par2 files: %s. Upload will continue without par2.", par2Paths), "error", err)
 			}
-			dropPar2FromNZB(nzbGen, createdPar2Paths)
+			dropPar2FromNZB(nzbGen, par2Paths)
 
 			return nil
 		}
@@ -432,7 +444,7 @@ func (p *Postie) post(
 	outputDir string,
 ) (string, error) {
 	var (
-		createdPar2Paths []string
+		par2Res          par2.Result
 		err              error
 		postingSucceeded bool
 	)
@@ -445,7 +457,7 @@ func (p *Postie) post(
 		}
 
 		if p.removePar2AfterPost() {
-			for _, path := range createdPar2Paths {
+			for _, path := range par2Res.Created {
 				safeRemoveFile(ctx, path)
 			}
 		}
@@ -467,7 +479,7 @@ func (p *Postie) post(
 		}
 		// If par2OutputDir is empty, CreateInDirectory will use default behavior (temp/source dir)
 
-		createdPar2Paths, err = p.par2runner.CreateInDirectory(ctx, []fileinfo.FileInfo{f}, par2OutputDir)
+		par2Res, err = p.par2runner.CreateInDirectory(ctx, []fileinfo.FileInfo{f}, par2OutputDir)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				slog.ErrorContext(ctx, "Error during par2 creation. Upload will continue without par2.", "error", err)
@@ -475,8 +487,9 @@ func (p *Postie) post(
 
 			return "", err
 		}
+		p.markGenerated(par2Res)
 
-		filesPath = append(filesPath, createdPar2Paths...)
+		filesPath = append(filesPath, par2Res.All()...)
 	}
 
 	var deferredErr *poster.DeferredCheckError
@@ -549,7 +562,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 	slog.InfoContext(ctx, "Posting folder as single NZB", "folder", folderName, "files", len(files))
 
 	var (
-		createdPar2Paths []string
+		par2Res          par2.Result
 		err              error
 		postingSucceeded bool
 	)
@@ -562,7 +575,7 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 		}
 
 		if p.removePar2AfterPost() {
-			for _, path := range createdPar2Paths {
+			for _, path := range par2Res.Created {
 				safeRemoveFile(ctx, path)
 			}
 		}
@@ -605,14 +618,15 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 				// folderDir is the on-disk root of the folder; FileDesc paths are computed
 				// relative to it so SABnzbd recreates the tree inside the job folder.
 				folderDir := filepath.Join(rootDir, folderName)
-				createdPar2Paths, err = p.par2runner.CreateSet(ctx, files, par2OutputDir, folderName, folderDir)
+				par2Res, err = p.par2runner.CreateSet(ctx, files, par2OutputDir, folderName, folderDir)
 				if err != nil {
 					if !errors.Is(err, context.Canceled) {
 						slog.ErrorContext(ctx, "Error during par2 creation. Upload will continue without par2.", "error", err)
 					}
 					// Continue without PAR2 files
 				} else {
-					allFilePaths = append(allFilePaths, createdPar2Paths...)
+					p.markGenerated(par2Res)
+					allFilePaths = append(allFilePaths, par2Res.All()...)
 					// par2 set files live at the folder root — basenames in NZB subjects.
 				}
 			}
@@ -674,21 +688,23 @@ func (p *Postie) postFolder(ctx context.Context, files []fileinfo.FileInfo, root
 			}
 
 			folderDir := filepath.Join(rootDir, folderName)
-			createdPar2Paths, err = p.par2runner.CreateSet(ctx, files, par2OutputDir, folderName, folderDir)
+			par2Res, err = p.par2runner.CreateSet(ctx, files, par2OutputDir, folderName, folderDir)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
 					slog.ErrorContext(ctx, "Error during par2 creation. Upload will continue without par2.", "error", err)
 				}
 				return nil
 			}
+			p.markGenerated(par2Res)
 
 			// par2 set files live at the folder root — basenames in NZB subjects.
+			par2Paths := par2Res.All()
 			par2RelPaths := map[string]string{}
-			if err := p.poster.PostWithRelativePaths(ctx, createdPar2Paths, rootDir, nzbGen, par2RelPaths); err != nil {
+			if err := p.poster.PostWithRelativePaths(ctx, par2Paths, rootDir, nzbGen, par2RelPaths); err != nil {
 				if !errors.Is(err, context.Canceled) {
 					slog.ErrorContext(ctx, "Error during upload of par2 files. Upload will continue without par2.", "error", err)
 				}
-				dropPar2FromNZB(nzbGen, createdPar2Paths)
+				dropPar2FromNZB(nzbGen, par2Paths)
 				return nil
 			}
 			return nil

--- a/pkg/postie/runtime.go
+++ b/pkg/postie/runtime.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 
 	nntppool "github.com/javi11/nntppool/v4"
 	"github.com/kipsilabs/postie/internal/config"
 	"github.com/kipsilabs/postie/internal/manifest"
 	"github.com/kipsilabs/postie/internal/par2"
+	"github.com/kipsilabs/postie/internal/par2sweep"
 	"github.com/kipsilabs/postie/internal/pool"
 	"github.com/kipsilabs/postie/internal/poster"
 	"github.com/kipsilabs/postie/internal/transfercleaner"
@@ -131,7 +134,25 @@ type Runtime struct {
 	store         *transferstore.Store
 	manifestDir   string
 	verifyService *verification.Service
+
+	// par2WorkDir is where generated PAR2 files land when temp_dir is set;
+	// the sweeper garbage-collects orphans there. Empty when PAR2 files are
+	// written next to the sources (never swept: the dir is not ours).
+	par2WorkDir string
+
+	// par2InUse counts, per path, the running jobs whose generated PAR2 files
+	// must not be swept yet.
+	par2Mu    sync.Mutex
+	par2InUse map[string]int
 }
+
+// Par2 work-dir sweep policy: a set is an orphan when no transfer references it,
+// no running job created it, and it has been untouched for par2SweepGrace.
+const (
+	par2SweepGrace        = 24 * time.Hour
+	par2SweepInitialDelay = 5 * time.Minute
+	par2SweepInterval     = time.Hour
+)
 
 // NewRuntime builds the shared transfer runtime from cfg. poolManager may be
 // nil; when it is (or when no upload connections are advertised) the upload
@@ -143,12 +164,14 @@ func NewRuntime(ctx context.Context, cfg config.Config, poolManager *pool.Manage
 	maxJobs := 1
 	var uploadEngine *poster.Engine
 	var verifyService *verification.Service
+	var par2WorkDir string
 
 	if cfg != nil {
 		par2Cfg, err := cfg.GetPar2Config(ctx)
 		if err != nil {
 			return nil, err
 		}
+		par2WorkDir = par2.WorkDir(par2Cfg)
 		if par2Cfg != nil && par2Cfg.MaxConcurrentJobs > 0 {
 			maxJobs = par2Cfg.MaxConcurrentJobs
 		}
@@ -212,7 +235,71 @@ func NewRuntime(ctx context.Context, cfg config.Config, poolManager *pool.Manage
 		store:         store,
 		manifestDir:   manifestDir,
 		verifyService: verifyService,
+		par2WorkDir:   par2WorkDir,
+		par2InUse:     map[string]int{},
 	}, nil
+}
+
+// ReservePar2 marks PAR2 files a running job generated as in use so the
+// sweeper leaves them alone until ReleasePar2. Safe on a nil runtime.
+func (r *Runtime) ReservePar2(paths ...string) {
+	if r == nil {
+		return
+	}
+	r.par2Mu.Lock()
+	defer r.par2Mu.Unlock()
+	if r.par2InUse == nil {
+		r.par2InUse = map[string]int{}
+	}
+	for _, p := range paths {
+		r.par2InUse[p]++
+	}
+}
+
+// ReleasePar2 undoes ReservePar2 for a finished job. Safe on a nil runtime.
+func (r *Runtime) ReleasePar2(paths ...string) {
+	if r == nil {
+		return
+	}
+	r.par2Mu.Lock()
+	defer r.par2Mu.Unlock()
+	for _, p := range paths {
+		if r.par2InUse[p] <= 1 {
+			delete(r.par2InUse, p)
+			continue
+		}
+		r.par2InUse[p]--
+	}
+}
+
+// Par2InUse lists the PAR2 files currently reserved by running jobs.
+func (r *Runtime) Par2InUse() []string {
+	if r == nil {
+		return nil
+	}
+	r.par2Mu.Lock()
+	defer r.par2Mu.Unlock()
+	out := make([]string, 0, len(r.par2InUse))
+	for p := range r.par2InUse {
+		out = append(out, p)
+	}
+	return out
+}
+
+// RunPar2Sweeper removes orphaned PAR2 sets from the work dir: a few minutes
+// after startup (so resumed jobs reserve their sets first) and then hourly. Files referenced by a transfer or reserved by a
+// running job are kept. No-op when PAR2 files are written next to the sources
+// (no temp_dir), since that directory is not Postie's to sweep. Intended to be
+// started once as a goroutine.
+func (r *Runtime) RunPar2Sweeper(ctx context.Context) {
+	if r == nil || r.par2WorkDir == "" {
+		return
+	}
+	var referenced func(context.Context) ([]string, error)
+	if r.store != nil {
+		referenced = r.store.ListSourcePaths
+	}
+	par2sweep.New(r.par2WorkDir, par2SweepGrace, referenced, r.Par2InUse).Run(ctx, par2SweepInitialDelay, par2SweepInterval)
 }
 
 // uploadConnectionCapacity sums the configured connection slots across all


### PR DESCRIPTION
## Summary

Addresses the last comment on #184: after a database reset and re-upload, the NZB contained hundreds of extra `.par2` entries (527 → 986 files in the reporter's screenshot). Also fixes #274 and the disk leak both stem from.

### 1. Stale PAR2 sets reused from the shared temp dir (#184)

**Root cause.** Generated PAR2 sets go to `par2.temp_dir` (default: OS temp dir, invisible inside Docker). In durable mode they are only removed by the transfer cleaner after verification, so a DB reset orphans them. On the next upload any set whose filename matched the source basename was reused without checking it was built from the same data, and volumes were collected with a loose prefix match that also picked up other uploads' `<name>*.vol*.par2` files.

**Fix**
- New `internal/par2/existing.go`: parse the main `.par2` File Description packets and reuse an on-disk set only if it describes exactly the input files (name, size, MD5 of first 16 KiB, mirroring par2go). Otherwise warn and regenerate.
- Volumes are matched strictly as `<base>.volN+M.par2`.
- Shared by the native and parpar executors, for single-file and folder sets.

### 2. Cleaner deleted users' own PAR2 files (#274)

**Root cause.** `transferwriter.roleFor` marked any `.par2` path as `generated_par2`, so reused user files were deleted by the cleaner after verification (and by standalone mode right after posting).

**Fix**
- `Par2Executor` returns `par2.Result{Created, Reused}`; Postie posts `All()`, deletes only `Created`, and calls `Recorder.MarkGenerated` for created paths before posting.
- The recorder derives the role from that set instead of the filename. Reused PAR2 files are recorded as originals and follow the `delete_original` policy.

### 3. Orphaned sets are now garbage-collected

- Generated files go into `<temp_dir>/postie-par2`, a directory Postie owns (empty `temp_dir` still means next to the sources, and nothing is swept there).
- New `internal/par2sweep`: removes `.par2` files in that dir older than 24h that no `transfer_files` row references and no running job has reserved. A failed store lookup aborts the pass without deleting.
- Runs 5 minutes after startup, then hourly. Jobs reserve every PAR2 file they post (created or reused) until they close.
- **Behaviour change:** users with an explicit `temp_dir` will see PAR2 files appear in a `postie-par2/` subfolder. Leftovers already in the old location are not swept.

## Test plan
- [x] Regression tests: strict volume matching, stale set with same name/different content rejected, folder set rejected when files added/removed/changed, garbage `.par2` rejected
- [x] `Result` split asserted in every existing reuse test (native + parpar executors); recorder role from `MarkGenerated`; reused PAR2 survives posting in standalone mode
- [x] Sweeper: removes only old, unreferenced, unreserved `.par2` files; keeps everything on lookup failure; honours the initial delay. Reservation of created and reused sets released on `Close`.
- [x] `go test -race ./internal/... ./pkg/...` green (`cmd/web` needs the frontend bundle, unrelated)
